### PR TITLE
Port - boy2mantwicethefam: Blood sucking fix

### DIFF
--- a/code/modules/wod13/verbs/bloodsucking.dm
+++ b/code/modules/wod13/verbs/bloodsucking.dm
@@ -36,15 +36,7 @@
 		var/mob/living/carbon/human/npc/NPC = mob
 		NPC.danger_source = null
 //		NPC.last_attacker = src
-
-	if(iskindred(mob))
-		to_chat(src, "<span class='userlove'>[mob]'s blood tastes HEAVENLY...</span>")
-		adjustBruteLoss(-25, TRUE)
-		adjustFireLoss(-25, TRUE)
-	else
-		mob.Stun(30)
-		to_chat(src, "<span class='warning'>You sip some <b>BLOOD</b> from your victim. It feels good.</span>")
-
+	mob.Stun(30)
 	if(mob.bloodpool <= 1 && mob.maxbloodpool > 1)
 		to_chat(src, "<span class='warning'>You feel small amount of <b>BLOOD</b> in your victim.</span>")
 		if(iskindred(mob))
@@ -125,9 +117,15 @@
 					client.images -= suckbar
 				qdel(suckbar)
 				return
+		if(iskindred(mob))
+			to_chat(src, "<span class='userlove'>[mob]'s blood tastes HEAVENLY...</span>")
+			adjustBruteLoss(-35, TRUE)
+			adjustFireLoss(-35, TRUE)
+		else
+			to_chat(src, "<span class='warning'>You sip some <b>BLOOD</b> from your victim. It feels good.</span>")
+			adjustBruteLoss(-10, TRUE)
+			adjustFireLoss(-10, TRUE)
 		bloodpool = min(maxbloodpool, bloodpool+1*max(1, mob.bloodquality-1))
-		adjustBruteLoss(-10, TRUE)
-		adjustFireLoss(-10, TRUE)
 		update_damage_overlays()
 		update_health_hud()
 		update_blood_hud()


### PR DESCRIPTION
Made the "you sip some blood from your victim" message not initially show up before actually sucking any blood from the victim.

Fixed a bug where you could repeatedly start the blood sucking process on a vampire, which would automatically heal you somewhat without even actually sucking any blood.

https://github.com/WorldOfDarknessXIII/World-of-Darkness-13/pull/455