### PR TITLE
Port - SpessMneme: QoL Changes

### DIFF
--- a/code/controllers/subsystem/job_scaling.dm
+++ b/code/controllers/subsystem/job_scaling.dm
@@ -1,0 +1,52 @@
+SUBSYSTEM_DEF(job_scaling)
+	name = "Job Scaling"
+	init_order = INIT_ORDER_JOBS + 1
+	wait = 10 SECONDS
+	flags = SS_BACKGROUND
+	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
+	var/list/scaling_rules = list()
+	var/last_player_count = 0  // track last count to avoid spam
+
+/datum/controller/subsystem/job_scaling/Initialize(timeofday)
+	setup_scaling_rules()
+	apply_initial_scaling()
+	return ..()
+
+/datum/controller/subsystem/job_scaling/fire()
+	var/total_players = length(GLOB.player_list)
+	if(total_players == last_player_count)  // skip if player count hasn't changed
+		return
+	last_player_count = total_players
+	for(var/job_title in scaling_rules)
+		var/datum/job/J = SSjob.GetJob(job_title)
+		if(!J)
+			continue
+		var/list/rule = scaling_rules[job_title]
+		var/players_per_slot = rule[1]
+		var/base_pop = rule[2]
+		var/max_additional = rule[3]
+		if(total_players <= base_pop)
+			continue
+		var/slots_needed = min(round((total_players - base_pop) / players_per_slot), max_additional)
+		var/slots_to_add = slots_needed - (J.total_positions - initial(J.total_positions))
+		if(slots_to_add > 0)
+			var/old_total = J.total_positions
+			J.total_positions += slots_to_add
+			message_admins("Job Scaling: Added [slots_to_add] [job_title] slot(s), Total_Positions increased from [old_total] to [J.total_positions]")
+
+/datum/controller/subsystem/job_scaling/proc/setup_scaling_rules()
+//police jobs
+	scaling_rules["Police Officer"] = list(10, 30, 10)  // 1 slot per 10 players over 30 players, up to 10 extra slots (15 max since 5 is the base)
+	scaling_rules["Police Sergeant"] = list(20, 30, 3) // 1 slot per 20 players over 30 players, up to 3 extra slots (5 max since 2 is the base)
+//civilian/human jobs
+	scaling_rules["Doctor"] = list(10, 30, 5)  // 1 slot per 10 players over 30 players, up to 5 extra slots (9 max since 4 is the base)
+	scaling_rules["Priest"] = list(10, 30, 3) // 1 slot per 10 players over 30 players, up to 3 extra slots (5 max since 2 is the base)
+	scaling_rules["Stripper"] = list(10, 30, 6) // 1 slot per 10 players over 30 players, up to 6 extra slots (10 max since 6 is the base)
+	scaling_rules["Street Janitor"] = list(10, 30, 4) // 1 slot per 10 players over 30 players, up to 4 extra slots (10 max since 6 is the base)
+//vampire jobs
+	scaling_rules["Scourge"] = list(10, 30, 3) // 1 slot per 10 players over 30 players, up to 3 extra slots (10 max since 7 is the base)
+	scaling_rules["Bruiser"] = list(10, 30, 3) // 1 slot per 10 players over 30 players, up to 3 extra slots (10 max since 7 is the base)
+	message_admins("Job Scaling: Rules initialized")
+
+/datum/controller/subsystem/job_scaling/proc/apply_initial_scaling()
+	fire()

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -235,6 +235,17 @@
 	icon_state = "satchel-norm"
 	inhand_icon_state = "satchel-norm"
 	component_type = /datum/component/storage/concrete/vtm/satchel
+	var/icon_hidden = FALSE
+
+/obj/item/storage/backpack/satchel/AltClick(mob/user)
+	if(!ishuman(user) || !user.canUseTopic(src, BE_CLOSE, NO_DEXTERITY, FALSE, TRUE))
+		return ..()
+	var/mob/living/carbon/human/H = user
+	if(src == H.back && H.w_uniform)
+		icon_hidden = !icon_hidden
+		worn_icon_state = icon_hidden ? "blank" : initial(worn_icon_state)
+		to_chat(H, "<span class='notice'>You [icon_hidden ? "conceal" : "reveal"] your [src].</span>")
+		H.update_inv_back()
 
 /obj/item/storage/backpack/satchel/leather
 	name = "leather satchel"

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -92,6 +92,15 @@
 			H.update_inv_wear_suit()
 
 /obj/item/clothing/under/dropped(mob/user)
+	. = ..()
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(H.back && istype(H.back, /obj/item/storage/backpack/satchel))
+			var/obj/item/storage/backpack/satchel/S = H.back
+			if(S.icon_hidden)
+				S.icon_hidden = FALSE
+				S.worn_icon_state = initial(S.worn_icon_state)
+				H.update_inv_back()
 	if(attached_accessory)
 		attached_accessory.on_uniform_dropped(src, user)
 		if(ishuman(user))

--- a/code/modules/vtmb/jobs/jobs.dm
+++ b/code/modules/vtmb/jobs/jobs.dm
@@ -301,8 +301,8 @@
 	worn_icon_state = "id12"
 
 /obj/item/card/id/police
-	name = "police department badge"
-	id_type_name = "police department badge"
+	name = "police officer badge"
+	id_type_name = "police officer badge"
 	desc = "Sponsored by the Government."
 	icon = 'code/modules/wod13/items.dmi'
 	icon_state = "id13"
@@ -314,15 +314,15 @@
 	worn_icon_state = "id13"
 
 /obj/item/card/id/police/sergeant
-	name = "police department badge"
+	name = "police sergeant badge"
 	desc = "Sponsored by the Government. This one seems slightly more worn down than all the others."
 
 /obj/item/card/id/police/chief
-	name = "police department badge"
+	name = "police chief badge"
 	desc = "Sponsored by the Government. This one has a chrome plated finish."
 
 /obj/item/card/id/police/fbi
-	name = "fbi agent badge"
+	name = "fbi special agent badge"
 	desc = "Sponsored by the Government. This one has all the bells and whistles."
 
 /obj/item/card/id/voivode

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -308,6 +308,7 @@
 #include "code\controllers\subsystem\input.dm"
 #include "code\controllers\subsystem\ipintel.dm"
 #include "code\controllers\subsystem\job.dm"
+#include "code\controllers\subsystem\job_scaling.dm"
 #include "code\controllers\subsystem\language.dm"
 #include "code\controllers\subsystem\lighting.dm"
 #include "code\controllers\subsystem\machines.dm"


### PR DESCRIPTION


    Creates a new subsystem which handles job scaling to ensure there are enough occupations outside of citizen for high-pop rounds. This impacts the following jobs:
        Police Officer: Scales 1 per 10 players above 30, max +10 slots (15 total since base is 5)
        Police Sergeant: Scales 1 per 20 players above 30, max +3 slots (5 total since base is 2)
        Doctor: Scales 1 per 10 players above 30, max +5 slots (9 total since base is 4)
        Priest: Scales 1 per 10 players above 30, max +3 slots (5 total since base is 2)
        Stripper: Scales 1 per 10 players above 30, max +6 slots (10 total since base is 4)
        Street Janitor: Scales 1 per 10 players above 30, max +4 slots (10 total since base is 6)
        Scourge: Scales 1 per 10 players above 30, max +3 slots (10 total since base is 7)
        Bruiser: Scales 1 per 10 players above 30, max +3 slots (10 total since base is 7)

    Makes it so you can conceal a satchel under your clothes with alt+click (aka hide the wearable icon) for immersion and roleplay purposes since most citizen/business/formal outfits look weird/unimmersive with a satchel sprite and taking it off is impractical as some sort of bag is basically a necessity for most jobs. I don't think this will cause any balance issues because it doesn't do anything but hide the wearable sprite. If you unequip your under it will show again.

    Tweaks the names of the Police IDs to better distinguish them from one another.
https://github.com/WorldOfDarknessXIII/World-of-Darkness-13/pull/466