### PR TITLE
Port - lucifernix: npc pool fixes

### DIFF
--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -31,6 +31,7 @@ GLOBAL_LIST_EMPTY(mob_living_list)				//all instances of /mob/living and subtype
 GLOBAL_LIST_EMPTY(carbon_list)				//all instances of /mob/living/carbon and subtypes, notably does not contain brains or simple animals
 GLOBAL_LIST_EMPTY(human_list)				//all instances of /mob/living/carbon/human and subtypes
 GLOBAL_LIST_EMPTY(npc_list)
+GLOBAL_LIST_EMPTY(alive_npc_list)
 GLOBAL_LIST_EMPTY(frenzy_list)
 GLOBAL_LIST_EMPTY(fires_list)
 GLOBAL_LIST_EMPTY(relationship_list)

--- a/code/controllers/subsystem/humannpcpool.dm
+++ b/code/controllers/subsystem/humannpcpool.dm
@@ -11,7 +11,8 @@ SUBSYSTEM_DEF(humannpcpool)
 
 /datum/controller/subsystem/humannpcpool/stat_entry(msg)
 	var/list/activelist = GLOB.npc_list
-	msg = "NPCS:[length(activelist)]"
+	var/list/living_list = GLOB.alive_npc_list
+	msg = "NPCS:[length(activelist)] Living: [length(living_list)]"
 	return ..()
 
 /datum/controller/subsystem/humannpcpool/fire(resumed = FALSE)
@@ -29,6 +30,7 @@ SUBSYSTEM_DEF(humannpcpool)
 
 		if (QDELETED(NPC)) // Some issue causes nulls to get into this list some times. This keeps it running, but the bug is still there.
 			GLOB.npc_list -= NPC		//HUH??? A BUG? NO WAY
+			GLOB.alive_npc_list -= NPC
 //			if(QDELETED(NPC))
 			log_world("Found a null in npc list!")
 //			else
@@ -41,9 +43,7 @@ SUBSYSTEM_DEF(humannpcpool)
 		NPC.handle_automated_movement()
 
 /datum/controller/subsystem/humannpcpool/proc/npclost()
-	if(length(GLOB.npc_list) < npc_max)
+	while(length(GLOB.alive_npc_list) < npc_max)
 		var/atom/kal = pick(GLOB.npc_spawn_points)
 		var/NEPIS = pick(/mob/living/carbon/human/npc/police, /mob/living/carbon/human/npc/bandit, /mob/living/carbon/human/npc/hobo, /mob/living/carbon/human/npc/walkby, /mob/living/carbon/human/npc/business)
 		new NEPIS(get_turf(kal))
-	else
-		return

--- a/code/modules/admin/view_variables/admin_delete.dm
+++ b/code/modules/admin/view_variables/admin_delete.dm
@@ -18,6 +18,9 @@
 			var/turf/T = D
 			T.ScrapeAway()
 		else
+			if(istype(D, /mob/living/carbon/human/npc))
+				GLOB.alive_npc_list -= D
+				GLOB.npc_list -= D
 			vv_update_display(D, "deleted", VV_MSG_DELETED)
 			qdel(D)
 			if(!QDELETED(D))

--- a/code/modules/vtmb/npc/beastmaster.dm
+++ b/code/modules/vtmb/npc/beastmaster.dm
@@ -26,6 +26,7 @@ SUBSYSTEM_DEF(beastmastering)
 
 		if (QDELETED(NPC)) // Some issue causes nulls to get into this list some times. This keeps it running, but the bug is still there.
 			GLOB.npc_list -= NPC
+			GLOB.alive_npc_list -= NPC
 			log_world("Found a null in npc list!")
 			continue
 

--- a/code/modules/wod13/npcs/npc_movement.dm
+++ b/code/modules/wod13/npcs/npc_movement.dm
@@ -32,9 +32,12 @@
 /mob/living/carbon/human/npc/Initialize()
 	..()
 	GLOB.npc_list += src
+	GLOB.alive_npc_list += src
 	add_movespeed_modifier(/datum/movespeed_modifier/npc)
 
 /mob/living/carbon/human/npc/death()
+	GLOB.alive_npc_list -= src
+	SShumannpcpool.npclost()
 	walk(src,0)
 	if(last_attacker && !key && !hostile)
 		if(get_dist(src, last_attacker) < 10)
@@ -69,13 +72,12 @@
 							SEND_SOUND(HM, sound('code/modules/wod13/sounds/sus.ogg', 0, 0, 75))
 							to_chat(HM, "<span class='userdanger'><b>SUSPICIOUS ACTION (murder)</b></span>")
 	remove_overlay(FIGHT_LAYER)
-	GLOB.npc_list -= src
-	SShumannpcpool.npclost() // [Lucifernix] - Removes dead NPCs from NPC list.
 	..()
 
 /mob/living/carbon/human/npc/Destroy()
 	..()
 	GLOB.npc_list -= src
+	GLOB.alive_npc_list -= src
 	SShumannpcpool.npclost()
 
 /mob/living/carbon/human/npc/Life()


### PR DESCRIPTION
Adds a pool for living npcs only, makes it so they properly get removed
from said list if they die and makes the respawn feature work as it
should be. Also makes it so admins deleting npcs actually removes them
from the pool.

https://github.com/WorldOfDarknessXIII/World-of-Darkness-13/pull/482