### PR TITLE
Port - boy2mantwicethefam:Scale Damage Overlay With Max Health

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -835,6 +835,8 @@
 
 	//Fire and Brute damage overlay (BSSR)
 	var/hurtdamage = getBruteLoss() + getFireLoss() + damageoverlaytemp
+	//Now adjust the damage in proportion to actual maxHealth, 20 damage is considered 10 damage on a mob with a maxHealth of 200
+	hurtdamage = hurtdamage * 100/(max(maxHealth, 1)) //No dividing with 0 in case maxHealth somehow becomes 0.
 	if(hurtdamage)
 		var/severity = 0
 		switch(hurtdamage)


### PR DESCRIPTION
"You're playing a vampire with more than triple the health of an average character, and someone shoots your character! That's bad! What's worse, even though your character only took around 90 damage you can barely see shit because of the big red overlay on the screen, even though the damage taken is proportionally not that great."

https://github.com/WorldOfDarknessXIII/World-of-Darkness-13/pull/489