### PR TITLE
Port - TheCarnalest: Require whitelists to learn certain Disciplines

### DIFF
--- a/code/controllers/subsystem/whitelists.dm
+++ b/code/controllers/subsystem/whitelists.dm
@@ -46,6 +46,11 @@ SUBSYSTEM_DEF(whitelists)
 		if (admin.ckey == checked_ckey)
 			return TRUE
 
+	//return as whitelisted if the given whitelist doesn't exist
+	if (!possible_whitelists.Find(checked_whitelist))
+		return TRUE
+
+
 	for (var/datum/whitelist/current_whitelist in whitelist_entries)
 		if ((current_whitelist.ckey == checked_ckey) && (current_whitelist.whitelist == checked_whitelist))
 			return TRUE

--- a/code/modules/vtmb/kindred_species.dm
+++ b/code/modules/vtmb/kindred_species.dm
@@ -573,6 +573,11 @@
 			for (var/i in 1 to client.prefs.discipline_types.len)
 				var/type_to_create = client.prefs.discipline_types[i]
 				var/datum/discipline/discipline = new type_to_create
+				//prevent Disciplines from being used if not whitelisted for them
+				if (discipline.clane_restricted)
+					if (!can_access_discipline(src, type_to_create))
+						qdel(discipline)
+						continue
 				discipline.level = client.prefs.discipline_levels[i]
 				adding_disciplines += discipline
 		else if (disciplines.len) //initialise given disciplines
@@ -710,6 +715,14 @@
 		var/datum/discipline/teacher_discipline = teacher_species.get_discipline(teaching_discipline)
 		var/datum/discipline/giving_discipline = new teaching_discipline
 
+		//if a Discipline is clan-restricted, it must be checked if the student has access to at least one Clan with that Discipline
+		if (giving_discipline.clane_restricted)
+			if (!can_access_discipline(student, teaching_discipline))
+				to_chat(teacher, "<span class='warning'>Your student is not whitelisted for any Clans with this Discipline, so they cannot learn it.</span>")
+				qdel(giving_discipline)
+				return
+
+		//ensure the teacher's mastered it, also prevents them from teaching with free starting experience
 		if (teacher_discipline.level < 5)
 			to_chat(teacher, "<span class='warning'>You do not know this Discipline well enough to teach it. You need to master it to the 5th rank.</span>")
 			qdel(giving_discipline)
@@ -717,30 +730,30 @@
 
 		var/restricted = giving_discipline.clane_restricted
 		if (restricted)
-			if (alert(teacher, "Are you sure you want to teach [student.name] [giving_discipline.name], one of your Clan's most tightly guarded secrets? This will cost 10 experience points.", "Confirmation", "Yes", "No") != "Yes")
+			if (alert(teacher, "Are you sure you want to teach [student] [giving_discipline], one of your Clan's most tightly guarded secrets? This will cost 10 experience points.", "Confirmation", "Yes", "No") != "Yes")
 				qdel(giving_discipline)
 				return
 		else
-			if (alert(teacher, "Are you sure you want to teach [student.name] [giving_discipline.name]? This will cost 10 experience points.", "Confirmation", "Yes", "No") != "Yes")
+			if (alert(teacher, "Are you sure you want to teach [student] [giving_discipline]? This will cost 10 experience points.", "Confirmation", "Yes", "No") != "Yes")
 				qdel(giving_discipline)
 				return
 
 		var/alienation = FALSE
 		if (student.clane.restricted_disciplines.Find(teaching_discipline))
-			if (alert(student, "Learning [giving_discipline.name] will alienate you from the rest of the [student.clane.name], making you just like the false Clan. Do you wish to continue?", "Confirmation", "Yes", "No") != "Yes")
-				visible_message("<span class='warning'>[student.name] refuses [teacher.name]'s mentoring!</span>")
+			if (alert(student, "Learning [giving_discipline] will alienate you from the rest of the [student.clane], making you just like the false Clan. Do you wish to continue?", "Confirmation", "Yes", "No") != "Yes")
+				visible_message("<span class='warning'>[student] refuses [teacher]'s mentoring!</span>")
 				qdel(giving_discipline)
 				return
 			else
 				alienation = TRUE
-				to_chat(teacher, "<span class='notice'>[student.name] accepts your mentoring!</span>")
+				to_chat(teacher, "<span class='notice'>[student] accepts your mentoring!</span>")
 
 		if (get_dist(student.loc, teacher.loc) > 1)
 			to_chat(teacher, "<span class='warning'>Your student needs to be next to you!</span>")
 			qdel(giving_discipline)
 			return
 
-		visible_message("<span class='notice'>[teacher.name] begins mentoring [student.name] in [giving_discipline.name].</span>")
+		visible_message("<span class='notice'>[teacher] begins mentoring [student] in [giving_discipline].</span>")
 		if (do_after(teacher, 30 SECONDS, student))
 			teacher_prefs.true_experience -= 10
 
@@ -749,10 +762,10 @@
 
 			if (alienation)
 				var/datum/vampireclane/main_clan
-				switch(student.clane.name)
-					if ("True Brujah")
+				switch(student.clane.type)
+					if (/datum/vampireclane/true_brujah)
 						main_clan = new /datum/vampireclane/brujah
-					if ("Old Clan Tzimisce")
+					if (/datum/vampireclane/old_clan_tzimisce)
 						main_clan = new /datum/vampireclane/tzimisce
 
 				student_prefs.clane = main_clan
@@ -761,10 +774,51 @@
 			student_prefs.save_character()
 			teacher_prefs.save_character()
 
-			to_chat(teacher, "<span class='notice'>You finish teaching [student.name] the basics of [giving_discipline.name]. They seem to have absorbed your mentoring. [restricted ? "May your Clanmates take mercy on your soul for spreading their secrets." : ""]</span>")
-			to_chat(student, "<span class='nicegreen'>[teacher.name] has taught you the basics of [giving_discipline.name]. You may now spend experience points to learn its first level in the character menu.</span>")
+			to_chat(teacher, "<span class='notice'>You finish teaching [student] the basics of [giving_discipline]. [student.p_they(TRUE)] seem[student.p_s()] to have absorbed your mentoring.[restricted ? " May your Clanmates take mercy on your soul for spreading their secrets." : ""]</span>")
+			to_chat(student, "<span class='nicegreen'>[teacher] has taught you the basics of [giving_discipline]. You may now spend experience points to learn its first level in the character menu.</span>")
 
 			message_admins("[ADMIN_LOOKUPFLW(teacher)] taught [ADMIN_LOOKUPFLW(student)] the Discipline [giving_discipline.name].")
 			log_game("[key_name(teacher)] taught [key_name(student)] the Discipline [giving_discipline.name].")
 
 		qdel(giving_discipline)
+
+/**
+ * Checks a vampire for whitelist access to a Discipline.
+ *
+ * Checks the given vampire to see if they have access to a certain Discipline through
+ * one of their selectable Clans. This is only necessary for "unique" or Clan-restricted
+ * Disciplines, as those have a chance to only be available to a certain Clan that
+ * the vampire may or may not be whitelisted for.
+ *
+ * Arguments:
+ * * vampire_checking - The vampire mob being checked for their access.
+ * * discipline_checking - The Discipline type that access to is being checked.
+ */
+/proc/can_access_discipline(mob/living/carbon/human/vampire_checking, discipline_checking)
+	if (!iskindred(vampire_checking))
+		return FALSE
+	if (!vampire_checking.client)
+		return FALSE
+	//make sure it's actually restricted and this check is necessary
+	var/datum/discipline/discipline_object_checking = new discipline_checking
+	if (!discipline_object_checking.clane_restricted)
+		qdel(discipline_object_checking)
+		return TRUE
+	qdel(discipline_object_checking)
+	//first, check their Clan Disciplines to see if that gives them access
+	if (vampire_checking.clane.clane_disciplines.Find(discipline_checking))
+		return TRUE
+	//next, go through all Clans to check if they have access to any with the Discipline
+	for (var/clan_type in subtypesof(/datum/vampireclane))
+		var/datum/vampireclane/clan_checking = new clan_type
+		//skip this if they can't access it due to whitelists
+		if (clan_checking.whitelisted)
+			if (!SSwhitelists.is_whitelisted(checked_ckey = vampire_checking.ckey, checked_whitelist = clan_checking.name))
+				qdel(clan_checking)
+				continue
+		if (clan_checking.clane_disciplines.Find(discipline_checking))
+			qdel(clan_checking)
+			return TRUE
+		qdel(clan_checking)
+	//nothing found
+	return FALSE

--- a/code/modules/vtmb/vampire_clane/baali.dm
+++ b/code/modules/vtmb/vampire_clane/baali.dm
@@ -3,9 +3,9 @@
 	desc = "The Baali are a bloodline of vampires associated with demon worship. Because of their affinity with the unholy, the Baali are particularly vulnerable to holy iconography, holy ground and holy water. They are highly vulnerable to True Faith."
 	curse = "Fear of the Religion."
 	clane_disciplines = list(
-		/datum/discipline/obfuscate = 1,
-		/datum/discipline/presence = 2,
-		/datum/discipline/daimonion = 3
+		/datum/discipline/obfuscate,
+		/datum/discipline/presence,
+		/datum/discipline/daimonion
 	)
 	male_clothes = /obj/item/clothing/under/vampire/baali
 	female_clothes = /obj/item/clothing/under/vampire/baali/female

--- a/code/modules/vtmb/vampire_clane/banu_haqim.dm
+++ b/code/modules/vtmb/vampire_clane/banu_haqim.dm
@@ -3,9 +3,9 @@
 	desc = "Banu Haqim, also known as Assamites, are traditionally seen by Western Kindred as dangerous assassins and diablerists, but in truth they are guardians, warriors, and scholars who seek to distance themselves from the Jyhad."
 	curse = "Blood Addiction."
 	clane_disciplines = list(
-		/datum/discipline/celerity = 1,
-		/datum/discipline/obfuscate = 2,
-		/datum/discipline/quietus = 3
+		/datum/discipline/celerity,
+		/datum/discipline/obfuscate,
+		/datum/discipline/quietus
 	)
 	male_clothes = /obj/item/clothing/under/vampire/bandit
 	female_clothes = /obj/item/clothing/under/vampire/bandit

--- a/code/modules/vtmb/vampire_clane/brujah.dm
+++ b/code/modules/vtmb/vampire_clane/brujah.dm
@@ -4,9 +4,9 @@
 	curse = "Increased frenzy chances and time."
 	frenzymod = 2
 	clane_disciplines = list(
-		/datum/discipline/celerity = 1,
-		/datum/discipline/potence = 2,
-		/datum/discipline/presence = 3
+		/datum/discipline/celerity,
+		/datum/discipline/potence,
+		/datum/discipline/presence
 	)
 	male_clothes = /obj/item/clothing/under/vampire/brujah
 	female_clothes = /obj/item/clothing/under/vampire/brujah/female

--- a/code/modules/vtmb/vampire_clane/cappadocian.dm
+++ b/code/modules/vtmb/vampire_clane/cappadocian.dm
@@ -3,9 +3,9 @@
 	desc = "A presumed-to-be-extinct Clan of necromancers, the Cappadocians studied death specifically in the physical world. The Giovanni were Embraced into their line to help further their studies into the underworld. They were rewarded with Diablerie and the destruction of their Clan and founder."
 	curse = "Extremely corpselike appearance that worsens with age."
 	clane_disciplines = list(
-		/datum/discipline/auspex = 1,
-		/datum/discipline/fortitude = 2,
-		/datum/discipline/necromancy = 3
+		/datum/discipline/auspex,
+		/datum/discipline/fortitude,
+		/datum/discipline/necromancy
 	)
 	violating_appearance = FALSE
 	alt_sprite = "rotten1"

--- a/code/modules/vtmb/vampire_clane/clane.dm
+++ b/code/modules/vtmb/vampire_clane/clane.dm
@@ -35,6 +35,7 @@ And it also helps for the character set panel
 	var/clan_keys //Keys to your hideout
 
 /datum/vampireclane/proc/on_gain(var/mob/living/carbon/human/H)
+	SHOULD_CALL_PARENT(TRUE)
 	if(length(accessories))
 		if(current_accessory)
 			H.remove_overlay(accessories_layers[current_accessory])
@@ -48,6 +49,16 @@ And it also helps for the character set panel
 		H.update_body_parts()
 		H.update_body()
 		H.update_icon()
+
+/datum/vampireclane/proc/post_gain(var/mob/living/carbon/human/H)
+	SHOULD_CALL_PARENT(TRUE)
+	if(violating_appearance && H.roundstart_vampire)
+		if(length(GLOB.masquerade_latejoin))
+			var/obj/effect/landmark/latejoin_masquerade/LM = pick(GLOB.masquerade_latejoin)
+			if(LM)
+				H.forceMove(LM.loc)
+	if(clan_keys)
+		H.put_in_r_hand(new clan_keys(H))
 
 /mob/living/carbon
 	var/datum/relationship/Myself
@@ -113,15 +124,6 @@ And it also helps for the character set panel
 							to_chat(owner, "Your lover, <b>[R.owner.real_name]</b>, is now in the city!")
 							to_chat(R.owner, "Your lover, <b>[owner.real_name]</b>, is now in the city!")
 							need_lover = FALSE
-
-/datum/vampireclane/proc/post_gain(var/mob/living/carbon/human/H)
-	if(violating_appearance && H.roundstart_vampire)
-		if(length(GLOB.masquerade_latejoin))
-			var/obj/effect/landmark/latejoin_masquerade/LM = pick(GLOB.masquerade_latejoin)
-			if(LM)
-				H.forceMove(LM.loc)
-	if(clan_keys)
-		H.put_in_r_hand(new clan_keys(H))
 
 /**
  * Rots the vampire's body along four stages of decay.

--- a/code/modules/vtmb/vampire_clane/doc.dm
+++ b/code/modules/vtmb/vampire_clane/doc.dm
@@ -3,9 +3,9 @@
 	desc = "Currently composed mostly of women (due to the associated difficulty in educating someone with the vocal range of most males), the Daughters practice Melpominee, a Discipline which allows the Daughters to invoke strange effects through singing. The Daughters are the choralistes par excellence of the undead, and hosting a gathering of them is worth high prestige for the Toreador."
 	curse = "Hear more than should."
 	clane_disciplines = list(
-		/datum/discipline/fortitude = 1,
-		/datum/discipline/melpominee = 2,
-		/datum/discipline/presence = 3
+		/datum/discipline/fortitude,
+		/datum/discipline/melpominee,
+		/datum/discipline/presence
 	)
 	male_clothes = /obj/item/clothing/under/vampire/sexy
 	female_clothes = /obj/item/clothing/under/vampire/toreador/female

--- a/code/modules/vtmb/vampire_clane/gangrel.dm
+++ b/code/modules/vtmb/vampire_clane/gangrel.dm
@@ -3,9 +3,9 @@
 	desc = "Often closer to beasts than other vampires, the Gangrel style themselves apex predators. These Ferals prowl the wilds as easily as the urban jungle, and no clan of vampires can match their ability to endure, survive, and thrive in any environment. Often fiercely territorial, their shapeshifting abilities even give the undead pause."
 	curse = "Start with lower humanity."
 	clane_disciplines = list(
-		/datum/discipline/animalism = 1,
-		/datum/discipline/fortitude = 2,
-		/datum/discipline/protean = 3
+		/datum/discipline/animalism,
+		/datum/discipline/fortitude,
+		/datum/discipline/protean
 	)
 	start_humanity = 6
 	male_clothes = /obj/item/clothing/under/vampire/gangrel

--- a/code/modules/vtmb/vampire_clane/gargoyle.dm
+++ b/code/modules/vtmb/vampire_clane/gargoyle.dm
@@ -3,9 +3,9 @@
 	desc = "The Gargoyles are a vampiric bloodline created by the Tremere as their servitors. Although technically not a Tremere bloodline, the bloodline is largely under their control. In the Final Nights, Gargoyle populations seem to be booming; this is largely because older, free Gargoyles are coming out of hiding to join the Camarilla, because more indentured Gargoyles break free from the clutches of the Tremere, and because the free Gargoyles have also begun to Embrace more mortals on their own."
 	curse = "All Gargoyles, much like the Nosferatu, are hideous to look at, a byproduct of their occult origins (and the varied Kindred stock from which they originate). This means that Gargoyles, just like the Nosferatu, have to hide their existence from common mortals, as their mere appearance is a breach of the Masquerade. In addition, the nature of the bloodline's origin manifests itself in the fact that Gargoyles are highly susceptible to mind control of any source. This weakness is intentional; a flaw placed into all Gargoyles by the Tremere in the hope that it would make them easier to control (and less likely to rebel)."
 	clane_disciplines = list(
-		/datum/discipline/fortitude = 1,
-		/datum/discipline/potence = 2,
-		/datum/discipline/visceratika = 3
+		/datum/discipline/fortitude,
+		/datum/discipline/potence,
+		/datum/discipline/visceratika
 	)
 	alt_sprite = "gargoyle"
 	no_facial = TRUE

--- a/code/modules/vtmb/vampire_clane/giovanni.dm
+++ b/code/modules/vtmb/vampire_clane/giovanni.dm
@@ -3,9 +3,9 @@
 	desc = "The Giovanni are the usurpers of Clan Cappadocian and one of the youngest clans. The Giovanni has historically been both a clan and a family. They Embrace almost exclusively within their family, and are heavily focused on the goals of money and necromantic power."
 	curse = "Harmful bites."
 	clane_disciplines = list(
-		/datum/discipline/potence = 1,
-		/datum/discipline/dominate = 2,
-		/datum/discipline/necromancy = 3
+		/datum/discipline/potence,
+		/datum/discipline/dominate,
+		/datum/discipline/necromancy
 	)
 	male_clothes = /obj/item/clothing/under/vampire/suit
 	female_clothes = /obj/item/clothing/under/vampire/suit/female

--- a/code/modules/vtmb/vampire_clane/kiasyd.dm
+++ b/code/modules/vtmb/vampire_clane/kiasyd.dm
@@ -3,9 +3,9 @@
 	desc = "The Kiasyd are a bloodline of the Lasombra founded after a mysterious \"accident\" involving the Lasombra Marconius of Strasbourg. The \"accident\", involving faeries and the blood of \"Zeernebooch, a god of the Underworld\", resulted in Marconius gaining several feet in height, turning chalky white and developing large, elongated black eyes."
 	curse = "At a glance they look unsettling or perturbing to most, their appearance closely resembles fae from old folklore. Kiasyd are also in some way connected with changelings and they are vulnerable to cold iron."
 	clane_disciplines = list(
-		/datum/discipline/dominate = 1,
-		/datum/discipline/obtenebration = 2,
-		/datum/discipline/mytherceria = 3
+		/datum/discipline/dominate,
+		/datum/discipline/obtenebration,
+		/datum/discipline/mytherceria
 	)
 	alt_sprite = "kiasyd"
 	no_facial = TRUE

--- a/code/modules/vtmb/vampire_clane/lasombra.dm
+++ b/code/modules/vtmb/vampire_clane/lasombra.dm
@@ -3,9 +3,9 @@
 	desc = "The Lasombra exist for their own success, fighting for personal victories rather than solely for a crown to wear or a throne to sit upon. They believe that might makes right, and are willing to sacrifice anything to achieve their goals. A clan that uses spirituality as a tool rather than seeking honest enlightenment, their fickle loyalties are currently highlighted by half their clan's defection from the Sabbat."
 	curse = "Technology refuse."
 	clane_disciplines = list(
-		/datum/discipline/potence = 1,
-		/datum/discipline/dominate = 2,
-		/datum/discipline/obtenebration = 3
+		/datum/discipline/potence,
+		/datum/discipline/dominate,
+		/datum/discipline/obtenebration
 	)
 	male_clothes = /obj/item/clothing/under/vampire/emo
 	female_clothes = /obj/item/clothing/under/vampire/business

--- a/code/modules/vtmb/vampire_clane/malkavian.dm
+++ b/code/modules/vtmb/vampire_clane/malkavian.dm
@@ -3,9 +3,9 @@
 	desc = "Derided as Lunatics by other vampires, the Blood of the Malkavians lets them perceive and foretell truths hidden from others. Like the �wise madmen� of poetry their fractured perspective stems from seeing too much of the world at once, from understanding too deeply, and feeling emotions that are just too strong to bear."
 	curse = "Insanity."
 	clane_disciplines = list(
-		/datum/discipline/auspex = 1,
-		/datum/discipline/dementation = 2,
-		/datum/discipline/obfuscate = 3
+		/datum/discipline/auspex,
+		/datum/discipline/dementation,
+		/datum/discipline/obfuscate
 	)
 	male_clothes = /obj/item/clothing/under/vampire/malkavian
 	female_clothes = /obj/item/clothing/under/vampire/malkavian/female

--- a/code/modules/vtmb/vampire_clane/ministry.dm
+++ b/code/modules/vtmb/vampire_clane/ministry.dm
@@ -3,9 +3,9 @@
 	desc = "The Ministry, also called the Ministry of Set, Followers of Set, or Setites, are a clan of vampires who believe their founder was the Egyptian god Set."
 	curse = "Decreased moving speed in lighted areas."
 	clane_disciplines = list(
-		/datum/discipline/obfuscate = 1,
-		/datum/discipline/presence = 2,
-		/datum/discipline/serpentis = 3
+		/datum/discipline/obfuscate,
+		/datum/discipline/presence,
+		/datum/discipline/serpentis
 	)
 	male_clothes = /obj/item/clothing/under/vampire/slickback
 	female_clothes = /obj/item/clothing/under/vampire/burlesque

--- a/code/modules/vtmb/vampire_clane/nosferatu.dm
+++ b/code/modules/vtmb/vampire_clane/nosferatu.dm
@@ -6,9 +6,9 @@
 //	no_hair = TRUE		//Pyotr from Hunter the Parenting had hair and it didn't go out of place in the setting. I'll do limited hairstyles
 	no_facial = TRUE
 	clane_disciplines = list(
-		/datum/discipline/animalism = 1,
-		/datum/discipline/potence = 2,
-		/datum/discipline/obfuscate = 3
+		/datum/discipline/animalism,
+		/datum/discipline/potence,
+		/datum/discipline/obfuscate
 	)
 	haircuts = list(
 		"Bald",

--- a/code/modules/vtmb/vampire_clane/old_clan_tzimisce.dm
+++ b/code/modules/vtmb/vampire_clane/old_clan_tzimisce.dm
@@ -3,9 +3,9 @@
 	desc = " The Old Clan Tzimisce are a small group of Fiends who predate the use of fleshcrafting. They regard Vicissitude as a disease of the soul, and refuse to learn or employ it. In most other respects, though, they resemble the rest of the Clan."
 	curse = "Grounded to material domain."
 	clane_disciplines = list(
-		/datum/discipline/auspex = 1,
-		/datum/discipline/animalism = 2,
-		/datum/discipline/dominate = 3
+		/datum/discipline/auspex,
+		/datum/discipline/animalism,
+		/datum/discipline/dominate
 	)
 	violating_appearance = FALSE
 	male_clothes = /obj/item/clothing/under/vampire/sport

--- a/code/modules/vtmb/vampire_clane/salubri.dm
+++ b/code/modules/vtmb/vampire_clane/salubri.dm
@@ -3,9 +3,9 @@
 	desc = "The Salubri are one of the original 13 clans of the vampiric descendants of Caine. Salubri believe that vampiric existence is torment from which Golconda or death is the only escape. Consequently, the modern Salubri would Embrace, teach a childe the basics of the route, leave clues for the childe to follow to achieve Golconda, and then have their childe diablerize them."
 	curse = "Hunted and consensual feeding."
 	clane_disciplines = list(
-		/datum/discipline/auspex = 1,
-		/datum/discipline/fortitude = 2,
-		/datum/discipline/valeren = 3
+		/datum/discipline/auspex,
+		/datum/discipline/fortitude,
+		/datum/discipline/valeren
 	)
 	male_clothes = /obj/item/clothing/under/vampire/salubri
 	female_clothes = /obj/item/clothing/under/vampire/salubri/female

--- a/code/modules/vtmb/vampire_clane/toreador.dm
+++ b/code/modules/vtmb/vampire_clane/toreador.dm
@@ -3,9 +3,9 @@
 	desc = "Known for their seductive nature, enthralling demeanor, and eloquent grace to the point of obsession, Toreador vampires Embrace artists and lovers into their ranks, forever trying to stir their own deadened hearts. Supernaturally graceful and charming, the Divas are always looking for the next thrill, leaving a detritus of discarded lovers and victims in their wake."
 	curse = "Doubled humanity changes."
 	clane_disciplines = list(
-		/datum/discipline/auspex = 1,
-		/datum/discipline/celerity = 2,
-		/datum/discipline/presence = 3
+		/datum/discipline/auspex,
+		/datum/discipline/celerity,
+		/datum/discipline/presence
 	)
 	humanitymod = 2
 	male_clothes = /obj/item/clothing/under/vampire/toreador

--- a/code/modules/vtmb/vampire_clane/tremere.dm
+++ b/code/modules/vtmb/vampire_clane/tremere.dm
@@ -3,9 +3,9 @@
 	desc = "The arcane Clan Tremere were once a house of mortal mages who sought immortality but found only undeath. As vampires, they’ve perfected ways to bend their own Blood to their will, employing their sorceries to master and ensorcel both the mortal and vampire world. Their power makes them valuable, but few vampires trust their scheming ways."
 	curse = "Blood magic."
 	clane_disciplines = list(
-		/datum/discipline/auspex = 1,
-		/datum/discipline/dominate = 2,
-		/datum/discipline/thaumaturgy = 3
+		/datum/discipline/auspex,
+		/datum/discipline/dominate,
+		/datum/discipline/thaumaturgy
 	)
 	male_clothes = /obj/item/clothing/under/vampire/tremere
 	female_clothes = /obj/item/clothing/under/vampire/tremere/female

--- a/code/modules/vtmb/vampire_clane/true_brujah.dm
+++ b/code/modules/vtmb/vampire_clane/true_brujah.dm
@@ -3,9 +3,9 @@
 	desc = "The True Brujah are a bloodline of Clan Brujah that claim to be descendants of the original Antediluvian founder of the lineage and not his diablerist/childe Troile. They are also noted for their calm, detached behavior, which puts them in contrast to the main lineage who are known for their rather short, violent tempers and anti-establishment attitudes. "
 	curse = "Absence of passion."
 	clane_disciplines = list(
-		/datum/discipline/potence = 1,
-		/datum/discipline/presence = 2,
-		/datum/discipline/temporis = 3
+		/datum/discipline/potence,
+		/datum/discipline/presence,
+		/datum/discipline/temporis
 	)
 	violating_appearance = FALSE
 	enlightenment = TRUE

--- a/code/modules/vtmb/vampire_clane/tzimisce.dm
+++ b/code/modules/vtmb/vampire_clane/tzimisce.dm
@@ -6,9 +6,9 @@
 //	no_hair = TRUE
 //	no_facial = TRUE	//FUCK WRONG RULEBOOK
 	clane_disciplines = list(
-		/datum/discipline/auspex = 1,
-		/datum/discipline/animalism = 2,
-		/datum/discipline/vicissitude = 3
+		/datum/discipline/auspex,
+		/datum/discipline/animalism,
+		/datum/discipline/vicissitude
 	)
 	violating_appearance = FALSE
 	male_clothes = /obj/item/clothing/under/vampire/sport

--- a/code/modules/vtmb/vampire_clane/ventrue.dm
+++ b/code/modules/vtmb/vampire_clane/ventrue.dm
@@ -3,9 +3,9 @@
 	desc = "The Ventrue are not called the Clan of Kings for nothing. Carefully choosing their progeny from mortals familiar with power, wealth, and influence, the Ventrue style themselves the aristocrats of the vampire world. Their members are expected to assume command wherever possible, and they’re willing to endure storms for the sake of leading from the front."
 	curse = "Low-rank and animal blood is disgusting."
 	clane_disciplines = list(
-		/datum/discipline/dominate = 1,
-		/datum/discipline/fortitude = 2,
-		/datum/discipline/presence = 3
+		/datum/discipline/dominate,
+		/datum/discipline/fortitude,
+		/datum/discipline/presence
 	)
 	male_clothes = /obj/item/clothing/under/vampire/ventrue
 	female_clothes = /obj/item/clothing/under/vampire/ventrue/female

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3404,7 +3404,7 @@
 #include "code\modules\vtmb\npc\defines.dm"
 #include "code\modules\vtmb\vampire_clane\baali.dm"
 #include "code\modules\vtmb\vampire_clane\banu_haqim.dm"
-#include "code\modules\vtmb\vampire_clane\bruja.dm"
+#include "code\modules\vtmb\vampire_clane\brujah.dm"
 #include "code\modules\vtmb\vampire_clane\caitiff.dm"
 #include "code\modules\vtmb\vampire_clane\cappadocian.dm"
 #include "code\modules\vtmb\vampire_clane\clane.dm"


### PR DESCRIPTION
"This adds a check when teaching people Disciplines to see if they have access to at least one Clan with the Discipline. This works to prevent Disciplines from whitelisted Clans being shared with people who do not have that whitelist.

Also does some code changes to make Clans and their code less weird, like tweaking the Discipline lists. Also renames bruja.dm to brujah.dm"
https://github.com/WorldOfDarknessXIII/World-of-Darkness-13/pull/388