### PR TITLE
bump up endorsement minimums

### DIFF
--- a/code/__DEFINES/vtr13/character_connections.dm
+++ b/code/__DEFINES/vtr13/character_connections.dm
@@ -5,8 +5,8 @@
 #define MEMBER_TYPE_THRALL "thrall"
 #define MEMBER_TYPE_DOMITOR "domitor"
 
-#define FACTION_HEAD_ENDORSEMENT_MIN 1 //how many endorsements the faction head needs in order to have their role.
-#define SENESCHAL_SPECIAL_ENDORSEMENT_MIN 1 //how many endorsements a seneschal needs from other faction heads to possess their role.
+#define FACTION_HEAD_ENDORSEMENT_MIN 3 //how many endorsements the faction head needs in order to have their role.
+#define SENESCHAL_SPECIAL_ENDORSEMENT_MIN 2 //how many endorsements a seneschal needs from other faction heads to possess their role.
 #define ENDORSEMENT_STALE_OFFSET_MONTHS 3 //how many months before an endorsement becomes stale from inactivity
 
 #define CONNECTION_ENDORSEMENT "endorsement"


### PR DESCRIPTION
Increases endorsement and special endorsement minimums to their intended values:

Faction heads require 3 endorsements from 3 vampires within their faction from separate ckeys.
The Seneschal requires 3 endorsements from 3 vampires in the invictus, and 2 endorsements from faction heads outside the invictus, all from separate ckeys.