### PR TITLE
fix pedestrian

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -150,15 +150,7 @@ SUBSYSTEM_DEF(job)
 		if((job.species_slots[player.client.prefs.pref_species.name] == 0) && !bypass)
 			JobDebug("FOC player species limit overrun, Player: [player]")
 			continue
-		if(player.client.prefs.pref_species.name == "Vampire")
-			if(player.client.prefs.clane)
-				var/alloww = FALSE
-				for(var/i in job.allowed_bloodlines)
-					if(i == player.client.prefs.clane.name)
-						alloww = TRUE
-				if(!alloww && !bypass)
-					JobDebug("FOC player clan not allowed, Player: [player]")
-					continue
+
 		if(flag && (!(flag in player.client.prefs.be_special)))
 			JobDebug("FOC flag failed, Player: [player], Flag: [flag], ")
 			continue
@@ -213,16 +205,6 @@ SUBSYSTEM_DEF(job)
 		if(job.species_slots[player.client.prefs.pref_species.name] == 0)
 			JobDebug("GRJ player species limit overrun, Player: [player]")
 			continue
-
-		if(player.client.prefs.pref_species.name == "Vampire")
-			if(player.client.prefs.clane)
-				var/alloww = FALSE
-				for(var/i in job.allowed_bloodlines)
-					if(i == player.client.prefs.clane.name)
-						alloww = TRUE
-				if(!alloww)
-					JobDebug("GRJ player clan not allowed, Player: [player]")
-					continue
 
 		if(player.mind && (job.title in player.mind.restricted_roles))
 			JobDebug("GRJ incompatible with antagonist role, Player: [player], Job: [job.title]")
@@ -424,15 +406,6 @@ SUBSYSTEM_DEF(job)
 					JobDebug("DO player species limit overrun, Player: [player]")
 					continue
 
-				if(player.client.prefs.pref_species.name == "Vampire")
-					if(player.client.prefs.clane)
-						var/alloww = FALSE
-						for(var/i in job.allowed_bloodlines)
-							if(i == player.client.prefs.clane.name)
-								alloww = TRUE
-						if(!alloww && !bypass)
-							JobDebug("DO player clan not allowed, Player: [player]")
-							continue
 
 				if(player.mind && (job.title in player.mind.restricted_roles))
 					JobDebug("DO incompatible with antagonist role, Player: [player], Job:[job.title]")

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -71,8 +71,9 @@ SUBSYSTEM_DEF(job)
 	var/datum/job/job = GetJob(rank)
 	if(!job)
 		return FALSE
-	if (mob?.dna?.species && job.species_slots[mob.dna.species.name] >= 0)
-		job.species_slots[mob.dna?.species.name]++
+	var/species_name = mob?.client?.prefs?.pref_species?.name
+	if (species_name && (job.species_slots_base[species_name]) && job.species_slots[species_name] >= 0)
+		job.species_slots[species_name] = min(job.species_slots_base[species_name], job.species_slots[species_name] + 1)
 	job.current_positions = max(0, job.current_positions - 1)
 
 /datum/controller/subsystem/job/proc/GetJob(rank)
@@ -89,8 +90,10 @@ SUBSYSTEM_DEF(job)
 	JobDebug("Running AR, Player: [player], Rank: [rank], LJ: [latejoin]")
 	if(player?.mind && rank)
 		var/bypass = FALSE
+		/*
 		if (check_rights_for(player.client, R_ADMIN))
 			bypass = TRUE
+			*/
 		var/datum/job/vamp/vtr/job = GetJob(rank)
 		if(!job)
 			return FALSE
@@ -106,7 +109,7 @@ SUBSYSTEM_DEF(job)
 			return FALSE
 		if(!job.allowed_species.Find(player.client.prefs.pref_species.name) && !bypass)
 			return FALSE
-		if ((job.species_slots[player.client.prefs.pref_species.name] == 0) && !bypass)
+		if ((job.species_slots_base[player.client.prefs.pref_species.name]) && (job.species_slots[player.client.prefs.pref_species.name] == 0) && !bypass)
 			return FALSE
 		var/position_limit = job.total_positions
 		if(!latejoin)
@@ -114,7 +117,7 @@ SUBSYSTEM_DEF(job)
 		JobDebug("Player: [player] is now Rank: [rank], JCP:[job.current_positions], JPL:[position_limit]")
 		player.mind.assigned_role = rank
 		unassigned -= player
-		if ((job.species_slots[player.client.prefs.pref_species.name] > 0) && !bypass)
+		if ((job.species_slots_base[player.client.prefs.pref_species.name]) && (job.species_slots[player.client.prefs.pref_species.name] > 0) && !bypass)
 			job.species_slots[player.client.prefs.pref_species.name]--
 		job.current_positions++
 		return TRUE
@@ -147,7 +150,7 @@ SUBSYSTEM_DEF(job)
 		if(!job.allowed_species.Find(player.client.prefs.pref_species.name) && !bypass)
 			JobDebug("FOC player species not allowed, Player: [player]")
 			continue
-		if((job.species_slots[player.client.prefs.pref_species.name] == 0) && !bypass)
+		if((job.species_slots_base[player.client.prefs.pref_species.name]) && (job.species_slots[player.client.prefs.pref_species.name] == 0) && !bypass)
 			JobDebug("FOC player species limit overrun, Player: [player]")
 			continue
 
@@ -202,7 +205,7 @@ SUBSYSTEM_DEF(job)
 			JobDebug("GRJ player species not allowed, Player: [player]")
 			continue
 
-		if(job.species_slots[player.client.prefs.pref_species.name] == 0)
+		if((job.species_slots_base[player.client.prefs.pref_species.name]) && job.species_slots[player.client.prefs.pref_species.name] == 0)
 			JobDebug("GRJ player species limit overrun, Player: [player]")
 			continue
 
@@ -402,7 +405,7 @@ SUBSYSTEM_DEF(job)
 					JobDebug("DO player species not allowed, Player: [player]")
 					continue
 
-				if((job.species_slots[player.client.prefs.pref_species.name] == 0) && !bypass)
+				if((job.species_slots_base[player.client.prefs.pref_species.name]) && (job.species_slots[player.client.prefs.pref_species.name] == 0) && !bypass)
 					JobDebug("DO player species limit overrun, Player: [player]")
 					continue
 

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -78,10 +78,10 @@
 
 	///List of species that are allowed to do this job.
 	var/list/allowed_species = list("Vampire")
+
 	///List of species that are limited to a certain amount of that species doing this job.
-	var/list/species_slots = list()
-	///List of Bloodlines that are allowed to do this job.
-	var/list/allowed_bloodlines = null
+	var/list/species_slots_base = list()
+	var/list/species_slots
 
 	// List for phone shit
 	var/my_contact_is_important = FALSE
@@ -105,6 +105,8 @@
 		spawn_positions = jobs_changes["spawn_positions"]
 	if(isnum(jobs_changes["total_positions"]))
 		total_positions = jobs_changes["total_positions"]
+	
+	species_slots = species_slots_base.Copy()
 
 //Only override this proc
 //H is usually a human unless an /equip override transformed it

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -81,7 +81,7 @@
 	///List of species that are limited to a certain amount of that species doing this job.
 	var/list/species_slots = list()
 	///List of Bloodlines that are allowed to do this job.
-	var/list/allowed_bloodlines = list("Brujah", "Tremere", "Ventrue", "Nosferatu", "Gangrel", "Toreador", "Malkavian", "Banu Haqim", "Giovanni", "Ministry")
+	var/list/allowed_bloodlines = null
 
 	// List for phone shit
 	var/my_contact_is_important = FALSE

--- a/code/modules/vtr13/jobs/_job_vtr.dm
+++ b/code/modules/vtr13/jobs/_job_vtr.dm
@@ -2,7 +2,7 @@
 	var/minimum_vamp_rank = 0	//minimum vampire rank for a position
 	var/endorsement_required = FALSE	//does this job work with the endorsement system
 
-/datum/job/after_spawn(mob/living/H, mob/M, latejoin = FALSE)
+/datum/job/vamp/vtr/after_spawn(mob/living/H, mob/M, latejoin = FALSE)
 	. = ..()
 	var/list/gear_leftovers
 

--- a/code/modules/vtr13/jobs/police_vtr.dm
+++ b/code/modules/vtr13/jobs/police_vtr.dm
@@ -15,7 +15,7 @@
 	exp_type_department = EXP_TYPE_POLICE
 
 	allowed_species = list("Ghoul", "Human")
-	species_slots = list("Ghoul" = 1)
+	species_slots_base = list("Ghoul" = 1)
 
 	duty = "Enforce the Law."
 	my_contact_is_important = FALSE

--- a/code/modules/vtr13/jobs/seneschal_vtr.dm
+++ b/code/modules/vtr13/jobs/seneschal_vtr.dm
@@ -27,8 +27,6 @@
 
 	minimum_vamp_rank = VAMP_RANK_ANCILLAE
 	allowed_species = list("Vampire")
-	allowed_bloodlines = list("Ventrue", "Daeva", "Mekhet", "Nosferatu", "Gangrel")
-
 	my_contact_is_important = TRUE
 	known_contacts = list(
 		"Page",

--- a/code/modules/vtr13/jobs/taxi_vtr.dm
+++ b/code/modules/vtr13/jobs/taxi_vtr.dm
@@ -20,8 +20,6 @@
 	v_duty = "Drive people in the city."
 	duty = "Drive people in the city."
 
-	allowed_bloodlines = list("Ventrue", "Daeva", "Mekhet", "Nosferatu", "Gangrel")
-
 /datum/job/vamp/vtr/taxi_vtr/after_spawn(mob/living/H, mob/M, latejoin = FALSE)
 	..()
 	H.taxist = TRUE

--- a/code/modules/vtr13/preferences/preferences_defines.dm
+++ b/code/modules/vtr13/preferences/preferences_defines.dm
@@ -181,7 +181,7 @@
 	var/persistent_scars = TRUE			/// If we have persistent scars enabled
 	var/reason_of_death = "None"
 
-	var/joblessrole = BERANDOMJOB		//defaults to BERANDOMJOB for fewer assistants
+	var/joblessrole = RETURNTOLOBBY		//defaults to BERANDOMJOB for fewer assistants
 	var/list/job_preferences = list()	//Job preferences 2.0 - indexed by job title , no key or value implies never
 	var/list/alt_titles_preferences = list()
 


### PR DESCRIPTION
 - Removes bloodline considerations from job selection
 - Fixes bug where leaving the round would create a species-locked slot for a role
 - Prevents admins from bypassing job limit restrictions without opening up a role about it
 - default unavailable job role is now being shunted back to the lobby.