### PR TITLE
fix ghouls not losing disciplines when switching regents

### DIFF
--- a/code/modules/vtr13/preferences/topic_procs/process_input_task_links.dm
+++ b/code/modules/vtr13/preferences/topic_procs/process_input_task_links.dm
@@ -324,6 +324,8 @@
 			if(result)
 				var/newtype = GLOB.clanes_list[result]
 				regent_clan = new newtype()
+				discipline_types.Cut()
+				discipline_levels.Cut()
 				for (var/disc_type in regent_clan.clane_disciplines)
 					discipline_types.Add(disc_type)
 					discipline_levels.Add(0)


### PR DESCRIPTION
What it says on the tin. stops ghouls from getting level 0 in a theoretically unlimited amount of of disciplines.