### PR TITLE
Fix Blood mist self-destruction

### DIFF
--- a/code/modules/vtr13/disciplines/protean/effects/blood_mist.dm
+++ b/code/modules/vtr13/disciplines/protean/effects/blood_mist.dm
@@ -5,11 +5,14 @@
 	color = "#9C3636"
 
 /obj/effect/particle_effect/smoke/blood_mist/smoke_mob(mob/living/carbon/inhaling_mob)
+	if(istype(inhaling_mob, /mob/living/simple_animal/hostile/blood_mist))
+		return
 	if(ishuman(inhaling_mob))
 		var/mob/living/carbon/human/human_inhaler = inhaling_mob
 		if(human_inhaler.bloodpool && prob(50))
 			human_inhaler.bloodpool = max(0, human_inhaler.bloodpool-1)
 			to_chat(inhaling_mob, "You feel blood leave your body!")
+	
 	inhaling_mob.adjustBruteLoss(5)
 	inhaling_mob.emote("cough")
 


### PR DESCRIPTION
 - prevents blood mist from attacking and draining the mist monster you turn into as part of the power.
