### PR TITLE
prevent minimaps from breaking on movement

### DIFF
--- a/code/modules/vtr13/items/travel_brochure.dm
+++ b/code/modules/vtr13/items/travel_brochure.dm
@@ -25,6 +25,7 @@
 	activated = TRUE
 	to_chat(user, span_notice("You begin reading the map..."))
 	if(!do_mob(user, user, 30)) //to prevent getflaticon spam
+		activated = FALSE
 		return
 	activated = FALSE
 	

--- a/code/modules/vtr13/preferences/merits/merits/direction_sense.dm
+++ b/code/modules/vtr13/preferences/merits/merits/direction_sense.dm
@@ -30,6 +30,7 @@
 		return
 	activated = TRUE
 	if(!do_mob(owner, owner, 3)) //to prevent getflaticon spam
+		activated = FALSE
 		return
 	activated = FALSE
 	var/render_pointer = TRUE


### PR DESCRIPTION
- Prevents minimaps from breaking forever if the character moves while reading/considering their location.