### PR TITLE
Hides hidden connections on character page, 2 months endorsement expiry

### DIFF
--- a/code/__DEFINES/vtr13/character_connections.dm
+++ b/code/__DEFINES/vtr13/character_connections.dm
@@ -7,7 +7,7 @@
 
 #define FACTION_HEAD_ENDORSEMENT_MIN 3 //how many endorsements the faction head needs in order to have their role.
 #define SENESCHAL_SPECIAL_ENDORSEMENT_MIN 2 //how many endorsements a seneschal needs from other faction heads to possess their role.
-#define ENDORSEMENT_STALE_OFFSET_MONTHS 3 //how many months before an endorsement becomes stale from inactivity
+#define ENDORSEMENT_STALE_OFFSET_MONTHS 2 //how many months before an endorsement becomes stale from inactivity
 
 #define CONNECTION_ENDORSEMENT "endorsement"
 #define CONNECTION_ENDORSEMENT_SENESCHAL "Endorsement for Seneschal"

--- a/code/modules/vtr13/preferences/html_procs/connections_page.dm
+++ b/code/modules/vtr13/preferences/html_procs/connections_page.dm
@@ -4,6 +4,8 @@
 	dat += "<table width=width='70%' cellpadding='5' align='center'>"
 	character_connections = SScharacter_connection.get_character_connections(parent.ckey, src.real_name)
 	for(var/datum/character_connection/connection in character_connections)
+		if(connection.hidden)
+			continue
 		dat += "<tr><td><b>[connection.connection_desc]</b></td><td><a href='byond://?_src_=prefs;preference=connection;task=delete_connection;connection_id=[connection.group_id];'>Delete</a></td></tr>"
 	
 	dat += "</table>"


### PR DESCRIPTION
- Endorsements expire after 2 months, instead of 3
- First stage Daeva addiction connections are now hidden on their preferences page, keep a little black book instead :)