### PR TITLE
Blown kisses only fluster targets charmed by majesty

### DIFF
--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -524,27 +524,39 @@
 	// people with the social anxiety quirk can get flustered when hit by a kiss
 	if((living_target.stat > SOFT_CRIT) || living_target.is_blind())
 		return
-	/*
-	if(HAS_TRAIT(living_target, TRAIT_FEARLESS) || prob(50)) // 50% chance for it to apply, also immune while on meds
+
+	if(!HAS_TRAIT_FROM(living_target, TRAIT_CHARMED, firer))
+		return
+
+	if(HAS_TRAIT(living_target, TRAIT_FEARLESS))
+		return
+
+	var/mob/living/firer_living = firer
+	if(!firer_living)
 		return
 
 	var/other_msg
 	var/self_msg
-	var/roll = rand(1, 3)
+	var/roll = SSroll.opposed_roll(firer_living, living_target, firer_living.get_charisma()*2, living_target.get_composure()*2, TRUE, TRUE, living_target, numerical= TRUE)
+	if(roll <= 0)
+		return
+
 	switch(roll)
 		if(1)
 			other_msg = "stumbles slightly, turning a bright red!"
 			self_msg = "You lose control of your limbs for a moment as your blood rushes to your face, turning it bright red!"
+			living_target.set_confusion(rand(5 SECONDS, 10 SECONDS))
 		if(2)
 			other_msg = "stammers softly for a moment before choking on something!"
 			self_msg = "You feel your tongue disappear down your throat as you fight to remember how to make words!"
-		if(3)
+			addtimer(CALLBACK(living_target, TYPE_PROC_REF(/atom/movable, say), pick("Uhhh...", "O-oh, uhm...", "I- uhhhhh??", "You too!!", "What?")), rand(0.5 SECONDS, 1.5 SECONDS))
+			living_target.stuttering = (rand(10 SECONDS, 30 SECONDS))
+		else
 			other_msg = "locks up with a stunned look on [living_target.p_their()] face, staring at [firer ? firer : "the ceiling"]!"
 			self_msg = "Your brain completely fails to process what just happened, leaving you rooted in place staring at [firer ? "[firer]" : "the ceiling"] for what feels like an eternity!"
 			living_target.face_atom(firer)
-
+			living_target.Stun(rand(3 SECONDS, 8 SECONDS))
 	living_target.visible_message("<b>[living_target]</b> [other_msg]", span_userdanger("Whoa! [self_msg]"))
-	*/
 
 /obj/projectile/kiss/on_hit(atom/target, blocked, pierce_hit)
 	. = ..()

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -524,6 +524,7 @@
 	// people with the social anxiety quirk can get flustered when hit by a kiss
 	if((living_target.stat > SOFT_CRIT) || living_target.is_blind())
 		return
+	/*
 	if(HAS_TRAIT(living_target, TRAIT_FEARLESS) || prob(50)) // 50% chance for it to apply, also immune while on meds
 		return
 
@@ -534,19 +535,16 @@
 		if(1)
 			other_msg = "stumbles slightly, turning a bright red!"
 			self_msg = "You lose control of your limbs for a moment as your blood rushes to your face, turning it bright red!"
-			living_target.set_confusion(rand(5 SECONDS, 10 SECONDS))
 		if(2)
 			other_msg = "stammers softly for a moment before choking on something!"
 			self_msg = "You feel your tongue disappear down your throat as you fight to remember how to make words!"
-			addtimer(CALLBACK(living_target, TYPE_PROC_REF(/atom/movable, say), pick("Uhhh...", "O-oh, uhm...", "I- uhhhhh??", "You too!!", "What?")), rand(0.5 SECONDS, 1.5 SECONDS))
-			living_target.stuttering = (rand(10 SECONDS, 30 SECONDS))
 		if(3)
 			other_msg = "locks up with a stunned look on [living_target.p_their()] face, staring at [firer ? firer : "the ceiling"]!"
 			self_msg = "Your brain completely fails to process what just happened, leaving you rooted in place staring at [firer ? "[firer]" : "the ceiling"] for what feels like an eternity!"
 			living_target.face_atom(firer)
-			living_target.Stun(rand(3 SECONDS, 8 SECONDS))
 
 	living_target.visible_message("<b>[living_target]</b> [other_msg]", span_userdanger("Whoa! [self_msg]"))
+	*/
 
 /obj/projectile/kiss/on_hit(atom/target, blocked, pierce_hit)
 	. = ..()


### PR DESCRIPTION
- Removes kisses causing confusion in the target and generating messages that may flow counter to their character's preferences.
- ...Unless they are charmed with Majesty 2. Then it becomes an opposed charisma vs composure roll :)