### PR TITLE
Adds multiple alt sprite options to Childe of Orlok

### DIFF
--- a/code/modules/vtr13/preferences/helper_procs/update_preview_icon.dm
+++ b/code/modules/vtr13/preferences/helper_procs/update_preview_icon.dm
@@ -29,7 +29,17 @@
 	mannequin.add_overlay(MAMA)
 	copy_to(mannequin, 1, TRUE, TRUE, loadout = show_loadout)
 	if(all_merits.Find("Childe of Orlok"))
-		mannequin.unique_body_sprite = "nosferatu"
+		switch(merit_custom_settings["alt_sprite"])
+			if("Otherworldly")
+				mannequin.unique_body_sprite = "kiasyd"
+			if("Rotten")
+				mannequin.unique_body_sprite = "rotten1"
+			if("Very Rotten")
+				mannequin.unique_body_sprite = "rotten2"
+			if("Extremely Rotten")
+				mannequin.unique_body_sprite = "rotten3"
+			else
+				mannequin.unique_body_sprite = "nosferatu"
 	else
 		mannequin.unique_body_sprite = null
 	mannequin.update_body()

--- a/code/modules/vtr13/preferences/merits/banes/childe_of_orlok.dm
+++ b/code/modules/vtr13/preferences/merits/banes/childe_of_orlok.dm
@@ -4,14 +4,27 @@
 	mob_trait = TRAIT_UGLY
 	clan_flags = MERIT_CLAN_NOSFERATU
 	human_only = TRUE
-
+	custom_setting_required = TRUE
+	custom_setting_types = "alt_sprite"
 
 /datum/merit/bane/childe_of_orlok/on_spawn()
 	. = ..()
+	var/chosen_sprite = custom_settings["alt_sprite"]
+	switch(chosen_sprite)
+		if("Classic")
+			chosen_sprite = "nosferatu"
+		if("Otherworldly")
+			chosen_sprite = "kiasyd"
+		if("Rotten")
+			chosen_sprite = "rotten1"
+		if("Very Rotten")
+			chosen_sprite = "rotten2"
+		if("Extremely Rotten")
+			chosen_sprite = "rotten3"
 	var/mob/living/carbon/human/human_merit_holder = merit_holder
 	if(!human_merit_holder?.dna?.species?.limbs_id)
 		return
-	human_merit_holder.unique_body_sprite = "nosferatu"
+	human_merit_holder.unique_body_sprite = chosen_sprite
 	human_merit_holder.update_body()
 	human_merit_holder.update_body()
 	human_merit_holder.update_icon()

--- a/code/modules/vtr13/preferences/merits/settings/alt_sprite.dm
+++ b/code/modules/vtr13/preferences/merits/settings/alt_sprite.dm
@@ -1,0 +1,10 @@
+/datum/merit_setting/alt_sprite
+	name = "alt_sprite"
+	parent_merit = /datum/merit/bane/childe_of_orlok
+	var/sprite_options = list("Classic", "Otherworldly", "Rotten", "Very Rotten", "Extremely Rotten")
+
+/datum/merit_setting/alt_sprite/populate_new_custom_value(mob/user)
+	var/response = tgui_input_list(user, "What grim visage has the curse bestowed on you?", "Custom Merit Settings", sprite_options, "Classic")
+	if(response)
+		return response
+

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3940,6 +3940,7 @@
 #include "code\modules\vtr13\preferences\merits\merits\producer.dm"
 #include "code\modules\vtr13\preferences\merits\merits\unseen_sense.dm"
 #include "code\modules\vtr13\preferences\merits\merits\wealthy.dm"
+#include "code\modules\vtr13\preferences\merits\settings\alt_sprite.dm"
 #include "code\modules\vtr13\preferences\merits\settings\expertise_stat.dm"
 #include "code\modules\vtr13\preferences\merits\settings\missing_arm.dm"
 #include "code\modules\vtr13\preferences\merits\subsystems\ssmerits.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Currently, Nosferatu can choose the Childe of Orlok bane, which sets their body sprite to the one used for Nosferatu in older WOD13 codebases and causes a masquerade violation if NPCs see their face. This PR keeps the core functionality, while allowing the player to select the currently-unused Kiasyd and Cappadocian (3 variations for various stages of decay) sprites instead. 

## Why It's Good For The Game

The Nosferatu curse is a varied thing and this, hopefully, allows _weird_ manifestations of the curse to be visually represented a little better.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/a3847afa-76fa-4ce8-b7a0-c1caa9542931)
![image](https://github.com/user-attachments/assets/df033694-8052-4a94-bdf9-5c4d8c644bff)
![image](https://github.com/user-attachments/assets/86a42d9a-028f-4969-b012-be46dc78e723)
![image](https://github.com/user-attachments/assets/53dabe7a-7740-44d0-9655-50b399cce0c2)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: the Childe of Orlok bane now offers a choice between five different sprites, for your own unique flavour of horror
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
