### PR TITLE
cosmetic crossbow changes

### DIFF
--- a/code/modules/wod13/guns.dm
+++ b/code/modules/wod13/guns.dm
@@ -733,11 +733,14 @@
 	lefthand_file = 'icons/wod13/righthand.dmi'
 	righthand_file = 'icons/wod13/lefthand.dmi'
 	onflooricon = 'icons/wod13/onfloor.dmi'
+	worn_icon = 'icons/wod13/worn.dmi'
 	icon_state = "crossbow0"
 	inhand_icon_state = "crossbow0"
+	worn_icon_state = "crossbow0"
 	fire_delay = 16
 	mag_type = /obj/item/ammo_box/magazine/internal/vampcrossbow
 	fire_sound = 'sound/items/syringeproj.ogg'
+	rack_sound = 'sound/weapons/draw_bow.ogg'
 	w_class = WEIGHT_CLASS_NORMAL
 	inhand_x_dimension = 32
 	inhand_y_dimension = 32


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The crossbow now uses the existing worn sprites. It didn't do this previously, so it was completely invisible.

Crossbow no longer makes a shotgun sound when you 'rack' it.

## Why It's Good For The Game

It's good when you can see that someone has a crossbow and can hear that it's not a shotgun.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
sound: crossbow no longer sounds like a gun
image: crossbow uses its worn state now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
