### PR TITLE
Players can no longer trigger Humanity 0 without admin input

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -540,7 +540,7 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 	if(!check_rights(R_ADMIN))
 		return
 
-	var/value = input(usr, "Enter the Humanity adjustment value for [M.key]:", "Humanity Adjustment", 0) as num|null
+	var/value = input(usr, "Enter the Humanity adjustment value for [M.key]. Their current humanity is [M.humanity].", "Humanity Adjustment", 0) as num|null
 	if(value == null)
 		return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

There is no gain in our current system to allowing players to trigger humanity 0 on their own. It is more likely to be accidental than anything, and with how drastic the effects are it makes more sense for an ahelp to be required much like it is for most humanity increases. Admins can still adjust humanity to 0, and the admin panel now tells them what the player's current humanity is when going to adjust the value.

I ended up rewriting the code for adjusthumanity entirely because it just looked kind of sloppy the way it was. Please read over it carefully before merging I'd hate to have done a silly lmao.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="500" height="107" alt="dreamseeker_o0JmIcrFLL" src="https://github.com/user-attachments/assets/491fb1f9-5c23-42a0-a77d-9bcbb4cbd763" />
<img width="483" height="123" alt="dreamseeker_0zsxIBDl1m" src="https://github.com/user-attachments/assets/9bf31fa6-0832-4edf-ad78-afa0309994b8" />
<img width="304" height="148" alt="dreamseeker_Ty1of9lpZ5" src="https://github.com/user-attachments/assets/5313295f-c3d5-49f2-8abc-86381dec1f7f" />


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Humanity no longer drops below 1 without admin input. Adjust Humanity admin panel now tells you current humanity on mob.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
