### PR TITLE
Allow players to set true name + new compel command

### DIFF
--- a/code/__DEFINES/vtr13/vtr13_preference_defines.dm
+++ b/code/__DEFINES/vtr13/vtr13_preference_defines.dm
@@ -5,7 +5,7 @@
 //	You do not need to raise this if you are adding new values that have sane defaults.
 //	Only raise this value when changing the meaning/format/name/layout of an existing value
 //	where you would want the updater procs below to run
-#define SAVEFILE_VERSION_MAX	43
+#define SAVEFILE_VERSION_MAX	44
 
 GLOBAL_LIST_EMPTY(preferences_datums)
 

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -75,7 +75,7 @@
 
 	output += "</center>"
 
-	
+
 
 
 	var/datum/browser/popup = new(src, "playersetup", "<div align='center'>[make_font_cool("NEW PLAYER")]</div>", 265, 280)
@@ -536,7 +536,7 @@
 		mind.original_character = H
 		mind.character_connections = SScharacter_connection.get_character_connections(ckey, real_name)
 		mind.transfer_to(H)					//won't transfer key since the mind is not active
-		
+
 	H.name = real_name
 	client.init_verbs()
 	. = H
@@ -552,7 +552,7 @@
 		if(ishuman(new_character))
 			var/mob/living/carbon/human/H = new_character
 			if(H.client)
-				H.true_real_name = H.client.prefs.real_name
+				H.true_real_name = H.client.prefs.true_real_name
 				H.create_disciplines()
 				GLOB.fucking_joined |= H.client.prefs.real_name
 			if(H.roundstart_vampire && H.breaks_masquerade_on_join())

--- a/code/modules/vtmb/gamemodes/bloodhunt.dm
+++ b/code/modules/vtmb/gamemodes/bloodhunt.dm
@@ -6,7 +6,7 @@
 	for(var/mob/living/carbon/human/H in SSbloodhunt.hunted)
 		if(H)
 			var/area/A = get_area(H)
-			to_chat(usr, "[icon2html(getFlatIcon(H), usr)][H.true_real_name], [H.mind ? H.mind.assigned_role : "Citizen"]. Was last seen at [A.name]")
+			to_chat(usr, "[icon2html(getFlatIcon(H), usr)][H.real_name], [H.mind ? H.mind.assigned_role : "Citizen"]. Was last seen at [A.name]")
 
 SUBSYSTEM_DEF(bloodhunt)
 	name = "Blood Hunt"
@@ -40,7 +40,7 @@ SUBSYSTEM_DEF(bloodhunt)
 		H.bloodhunted = TRUE
 		for(var/mob/living/carbon/human/R in GLOB.player_list)
 			if(R && iskindred(R) && R.client)
-				to_chat(R, "<b>The Blood Hunt after <span class='warning'>[H.true_real_name]</span> has been announced! <br> Reason: [reason]</b>")
+				to_chat(R, "<b>The Blood Hunt after <span class='warning'>[H.real_name]</span> has been announced! <br> Reason: [reason]</b>")
 				SEND_SOUND(R, sound('code/modules/wod13/sounds/announce.ogg'))
 		hunted += H
 		update_shit()

--- a/code/modules/vtmb/jobs/jobs.dm
+++ b/code/modules/vtmb/jobs/jobs.dm
@@ -10,7 +10,7 @@
 			for(var/obj/item/vamp/creditcard/a_card in b.contents)
 				if(a_card)
 					H.bank_id = a_card.account.bank_id
-					a_card.account.account_owner = H.true_real_name
+					a_card.account.account_owner = H.real_name
 					a_card.account.tracked_owner_mob = WEAKREF(H)
 					a_card.has_checked = TRUE
 

--- a/code/modules/vtr13/connections/blood_bonds/create_blood_bond_to.dm
+++ b/code/modules/vtr13/connections/blood_bonds/create_blood_bond_to.dm
@@ -3,8 +3,8 @@
 		return 0
 
 	var/bond_type = CONNECTION_BLOOD_BOND_1
-	var/thrall_description = "I am bound by a first-stage blood bond to [domitor.true_real_name]."
-	var/domitor_description = "I have put a first-stage blood bond upon [thrall.true_real_name]."
+	var/thrall_description = "I am bound by a first-stage blood bond to [domitor.real_name]."
+	var/domitor_description = "I have put a first-stage blood bond upon [thrall.real_name]."
 	var/resulting_bond = 1
 
 	var/datum/character_connection/existing_connection = SScharacter_connection.get_existing_mutual_blood_bond(thrall, domitor)
@@ -12,13 +12,13 @@
 		switch(existing_connection.group_type)
 			if(CONNECTION_BLOOD_BOND_1)
 				bond_type = CONNECTION_BLOOD_BOND_2
-				thrall_description = "I am enraptured by a second-stage blood bond to [domitor.true_real_name]."
-				domitor_description = "I have caught [thrall.true_real_name] in a second-stage blood bond."
+				thrall_description = "I am enraptured by a second-stage blood bond to [domitor.real_name]."
+				domitor_description = "I have caught [thrall.real_name] in a second-stage blood bond."
 				resulting_bond = 2
 			if(CONNECTION_BLOOD_BOND_2)
 				bond_type = CONNECTION_BLOOD_BOND_3
-				thrall_description = "I am a Thrall, transfixed by a third-stage blood bond to [domitor.true_real_name], my Regent."
-				domitor_description = "I have trapped [thrall.true_real_name] in a third-stage blood bond. I am their Regent and they are my Thrall."
+				thrall_description = "I am a Thrall, transfixed by a third-stage blood bond to [domitor.real_name], my Regent."
+				domitor_description = "I have trapped [thrall.real_name] in a third-stage blood bond. I am their Regent and they are my Thrall."
 				resulting_bond = 3
 			if(CONNECTION_BLOOD_BOND_3)
 				return 3 //A blood bond can not go higher than stage 3
@@ -30,7 +30,7 @@
 	switch(bond_type)
 		if(CONNECTION_BLOOD_BOND_1)
 			to_chat(thrall, "<span class='userlove'>You feel a deep sense of familiarity with [domitor].</span>")
-		
+
 		if(CONNECTION_BLOOD_BOND_2)
 			to_chat(thrall, "<span class='userlove'>You begin to long for [domitor]'s presence.</span>")
 

--- a/code/modules/vtr13/connections/boons/boon.dm
+++ b/code/modules/vtr13/connections/boons/boon.dm
@@ -18,8 +18,8 @@
 
 
 /datum/character_connection_type/boon/attempt_connection_add(mob/living/recipient, mob/living/granter)
-	var/granter_phrase = "I owe [recipient.true_real_name] a [src.name]."
-	var/recipient_phrase = "[granter.true_real_name] owes you a [src.name]."
+	var/granter_phrase = "I owe [recipient.real_name] a [src.name]."
+	var/recipient_phrase = "[granter.real_name] owes you a [src.name]."
 
 	var/group_id = SScharacter_connection.insert_character_connection(granter, src.name, MEMBER_TYPE_BOON_GRANTER, granter_phrase)
 

--- a/code/modules/vtr13/connections/daeva_addiction/daeva_addiction.dm
+++ b/code/modules/vtr13/connections/daeva_addiction/daeva_addiction.dm
@@ -16,7 +16,7 @@
 	if(!daeva || !daeva.mind)
 		return 0
 
-	if(!daeva.true_real_name || !victim.true_real_name)
+	if(!daeva.real_name || !victim.real_name)
 		return 0
 
 	if(!iskindred(daeva))
@@ -42,19 +42,19 @@
 		to_chat(daeva, "<span class='userlove'>As you drink, the Wanton Curse has its due. You become deeply obsessed with [victim].</span>")
 		SScharacter_connection.update_retire_character_connection_by_group_id(existing_addiction.group_id)
 		group_type = CONNECTION_DAEVA_ADDITION_2
-	
+
 	var/daeva_connection_desc = ""
 	var/victim_connection_desc = ""
 	var/hidden = FALSE
 	var/return_val = 1
 	switch(group_type)
 		if(CONNECTION_DAEVA_ADDITION_1)
-			daeva_connection_desc = "You have drank from [victim.true_real_name] once."
-			victim_connection_desc = "[daeva.true_real_name] has drank your blood once."
+			daeva_connection_desc = "You have drank from [victim.real_name] once."
+			victim_connection_desc = "[daeva.real_name] has drank your blood once."
 			hidden = TRUE
 		if(CONNECTION_DAEVA_ADDITION_2)
-			daeva_connection_desc = "You are obsessed with [victim.true_real_name]."
-			victim_connection_desc = "[daeva.true_real_name] is obsessed with you."
+			daeva_connection_desc = "You are obsessed with [victim.real_name]."
+			victim_connection_desc = "[daeva.real_name] is obsessed with you."
 			return_val = 2
 
 	//insert victim connection

--- a/code/modules/vtr13/connections/embraces/embrace.dm
+++ b/code/modules/vtr13/connections/embraces/embrace.dm
@@ -4,16 +4,16 @@
 /datum/character_connection_type/embrace/attempt_connection_add(mob/living/childe, mob/living/sire)
 	if(!childe || !sire)
 		return FALSE
-	var/sire_description = "I am [childe.true_real_name]'s sire."
-	var/childe_description = "I am [sire.true_real_name]'s childe."
+	var/sire_description = "I am [childe.real_name]'s sire."
+	var/childe_description = "I am [sire.real_name]'s childe."
 	var/new_group_id = SScharacter_connection.insert_character_connection(childe,
-			CONNECTION_EMBRACE, 
+			CONNECTION_EMBRACE,
 			MEMBER_TYPE_CHILDE,
 			childe_description,
 			null)
 	SScharacter_connection.insert_character_connection(
 		sire,
-		CONNECTION_EMBRACE, 
+		CONNECTION_EMBRACE,
 		MEMBER_TYPE_SIRE,
 		sire_description,
 		new_group_id)

--- a/code/modules/vtr13/connections/endorsements/endorsement.dm
+++ b/code/modules/vtr13/connections/endorsements/endorsement.dm
@@ -10,13 +10,13 @@
 /datum/character_connection_type/endorsement/add_connection(mob/living/carbon/human/candidate, mob/living/carbon/human/endorser)
 	if(!candidate?.mind || !endorser?.mind)
 		return FALSE
-	
+
 	//your char must have the prerequisite rank in vampire society
 	if(minimum_endorser_rank && endorser.vamp_rank < minimum_endorser_rank)
 		to_chat(endorser, span_notice("You must be at least a [GLOB.vampire_rank_names[minimum_endorser_rank]] to endorse [candidate] for [desired_position]."))
 		to_chat(candidate, span_notice("[endorser] must be at least a [GLOB.vampire_rank_names[minimum_endorser_rank]] to endorse you for [desired_position]."))
 		return FALSE
-	
+
 	if(minimum_candidate_rank && candidate.vamp_rank < minimum_candidate_rank)
 		to_chat(candidate, span_notice("You must be at least a [GLOB.vampire_rank_names[minimum_candidate_rank]] to be endorsed for [desired_position]."))
 		to_chat(endorser, span_notice("[candidate] must be at least a [GLOB.vampire_rank_names[minimum_candidate_rank]] before you can endorse them for [desired_position]."))
@@ -37,8 +37,8 @@
 
 /datum/character_connection_type/endorsement/attempt_connection_add(mob/living/candidate, mob/living/carbon/human/endorser)
 
-	var/candidate_phrase = "[endorser.true_real_name][endorser_must_be_faction_head?", as a faction head,":""] endorses me for the position of [desired_position]."
-	var/endorser_phrase = "I endorse [candidate.true_real_name][endorser_must_be_faction_head?", as a faction head,":""] for the position of [desired_position]."
+	var/candidate_phrase = "[endorser.real_name][endorser_must_be_faction_head?", as a faction head,":""] endorses me for the position of [desired_position]."
+	var/endorser_phrase = "I endorse [candidate.real_name][endorser_must_be_faction_head?", as a faction head,":""] for the position of [desired_position]."
 
 	var/group_id = SScharacter_connection.insert_character_connection(candidate, src.name, MEMBER_TYPE_CANDIDATE, candidate_phrase)
 
@@ -49,6 +49,6 @@
 		return FALSE
 
 	to_chat(candidate, span_notice("[endorser] endorses you for the position of [desired_position]."))
-	to_chat(endorser, span_notice("You endorse [candidate.true_real_name] for the position of [desired_position]."))
+	to_chat(endorser, span_notice("You endorse [candidate.real_name] for the position of [desired_position]."))
 
 	return TRUE

--- a/code/modules/vtr13/connections/subsystems/SScharacter_connection.dm
+++ b/code/modules/vtr13/connections/subsystems/SScharacter_connection.dm
@@ -1,6 +1,6 @@
 /*
-	Subsystem for handling character connections. 
-	All character connection stuff should try to use this subsystem and its 
+	Subsystem for handling character connections.
+	All character connection stuff should try to use this subsystem and its
 	multitude of procs as an intermediary.
 */
 SUBSYSTEM_DEF(character_connection)
@@ -17,7 +17,7 @@ SUBSYSTEM_DEF(character_connection)
 
 	//List of connection types that do not need to be loaded into our global list
 	var/list/exception_types = list(
-		/datum/character_connection_type, 
+		/datum/character_connection_type,
 		/datum/character_connection_type/endorsement,
 		/datum/character_connection_type/boon)
 
@@ -36,7 +36,7 @@ SUBSYSTEM_DEF(character_connection)
 				if(!endorsement_connection_list["[endorsement_connection.required_faction]"])
 					endorsement_connection_list["[endorsement_connection.required_faction]"] = list()
 				endorsement_connection_list["[endorsement_connection.required_faction]"]["[endorsement_connection.name]"] = endorsement_connection
-			else 
+			else
 				if(!endorsement_connection_list["Other"])
 					endorsement_connection_list["Other"] = list()
 				endorsement_connection_list["Other"]["[endorsement_connection.name]"] = endorsement_connection
@@ -55,14 +55,14 @@ SUBSYSTEM_DEF(character_connection)
 	var/datum/character_connection_type/connection_type = get_character_connection_type(connection_type_name)
 	if(!connection_type)
 		CRASH("Tried to create a connection of type [connection_type_name] and it wasn't loaded!")
-	
+
 	var/response = connection_type.add_connection(arglist(args.Copy(2)))
-	
+
 	if(player_a.mind)
-		player_a.mind.character_connections = SScharacter_connection.get_character_connections(player_a.ckey, player_a.true_real_name)
+		player_a.mind.character_connections = SScharacter_connection.get_character_connections(player_a.ckey, player_a.real_name)
 
 	if(player_b.mind)
-		player_b.mind.character_connections = SScharacter_connection.get_character_connections(player_b.ckey, player_b.true_real_name)
+		player_b.mind.character_connections = SScharacter_connection.get_character_connections(player_b.ckey, player_b.real_name)
 
 	return response
 

--- a/code/modules/vtr13/connections/subsystems/SScharacter_connection_procs/create_artificial_connection.dm
+++ b/code/modules/vtr13/connections/subsystems/SScharacter_connection_procs/create_artificial_connection.dm
@@ -3,10 +3,10 @@
 	if(!party_a?.mind || !party_b?.mind)
 		return
 
-	var/datum/character_connection/fake_connection_a = new (null, null, bond_type, member_type_a, party_a.ckey, party_a.true_real_name, "[bond_description_a] (Temporary)", GLOB.round_id)
+	var/datum/character_connection/fake_connection_a = new (null, null, bond_type, member_type_a, party_a.ckey, party_a.real_name, "[bond_description_a] (Temporary)", GLOB.round_id)
 	LAZYADD(party_a.mind.fake_character_connections, fake_connection_a)
 
-	var/datum/character_connection/fake_connection_b = new (null, null, bond_type, member_type_b, party_b.ckey, party_b.true_real_name, "[bond_description_b] (Temporary)", GLOB.round_id)
+	var/datum/character_connection/fake_connection_b = new (null, null, bond_type, member_type_b, party_b.ckey, party_b.real_name, "[bond_description_b] (Temporary)", GLOB.round_id)
 	LAZYADD(party_b.mind.fake_character_connections, fake_connection_b)
 
 	if(replacing_connection)

--- a/code/modules/vtr13/connections/subsystems/SScharacter_connection_procs/db_operations/blood_bonds/check_character_level_three_blood_bonds.dm
+++ b/code/modules/vtr13/connections/subsystems/SScharacter_connection_procs/db_operations/blood_bonds/check_character_level_three_blood_bonds.dm
@@ -11,10 +11,10 @@
 			date_ended IS NULL AND \
 			group_type = :bb3 AND \
 			member_type = :member_type \
-		LIMIT 1", 
+		LIMIT 1",
 		list(
 			"ckey" = target.ckey,
-			"char_name" = target.true_real_name,
+			"char_name" = target.real_name,
 			"bb3" = CONNECTION_BLOOD_BOND_3,
 			"member_type" = MEMBER_TYPE_THRALL
 		)

--- a/code/modules/vtr13/connections/subsystems/SScharacter_connection_procs/db_operations/blood_bonds/check_mutual_blood_bonds_made_this_round.dm
+++ b/code/modules/vtr13/connections/subsystems/SScharacter_connection_procs/db_operations/blood_bonds/check_mutual_blood_bonds_made_this_round.dm
@@ -23,12 +23,12 @@
 		LIMIT 1",
 		list(
 			"ckey" = thrall.ckey,
-			"char_name" = thrall.true_real_name,
+			"char_name" = thrall.real_name,
 			"bb2" = CONNECTION_BLOOD_BOND_2,
 			"bb1" = CONNECTION_BLOOD_BOND_1,
 			"member_type" = MEMBER_TYPE_THRALL,
 			"domitor_ckey" = domitor.ckey,
-			"domitor_name" = domitor.true_real_name,
+			"domitor_name" = domitor.real_name,
 			"round_id" = GLOB.round_id
 		)
 	)

--- a/code/modules/vtr13/connections/subsystems/SScharacter_connection_procs/db_operations/blood_bonds/get_existing_mutual_blood_bond.dm
+++ b/code/modules/vtr13/connections/subsystems/SScharacter_connection_procs/db_operations/blood_bonds/get_existing_mutual_blood_bond.dm
@@ -24,13 +24,13 @@
 		LIMIT 1",
 		list(
 			"ckey" = thrall.ckey,
-			"char_name" = thrall.true_real_name,
+			"char_name" = thrall.real_name,
 			"bb3" = CONNECTION_BLOOD_BOND_3,
 			"bb2" = CONNECTION_BLOOD_BOND_2,
 			"bb1" = CONNECTION_BLOOD_BOND_1,
 			"member_type" = MEMBER_TYPE_THRALL,
 			"domitor_ckey" = domitor.ckey,
-			"domitor_name" = domitor.true_real_name
+			"domitor_name" = domitor.real_name
 		)
 	)
 

--- a/code/modules/vtr13/connections/subsystems/SScharacter_connection_procs/db_operations/blood_bonds/update_retire_all_blood_bonds.dm
+++ b/code/modules/vtr13/connections/subsystems/SScharacter_connection_procs/db_operations/blood_bonds/update_retire_all_blood_bonds.dm
@@ -13,11 +13,11 @@
 						member_type = :m_type AND \
 						group_type IN (:bb1,:bb2,:bb3)\
 				)",
-		list("ckey" = target.ckey, 
-			"char_name" = target.true_real_name, 
-			"m_type" = MEMBER_TYPE_THRALL, 
-			"bb1" = CONNECTION_BLOOD_BOND_1, 
-			"bb2" = CONNECTION_BLOOD_BOND_2, 
+		list("ckey" = target.ckey,
+			"char_name" = target.real_name,
+			"m_type" = MEMBER_TYPE_THRALL,
+			"bb1" = CONNECTION_BLOOD_BOND_1,
+			"bb2" = CONNECTION_BLOOD_BOND_2,
 			"bb3" = CONNECTION_BLOOD_BOND_3)
 	)
 	query.Execute()

--- a/code/modules/vtr13/connections/subsystems/SScharacter_connection_procs/db_operations/daeva_addiction/get_existing_daeva_addiction.dm
+++ b/code/modules/vtr13/connections/subsystems/SScharacter_connection_procs/db_operations/daeva_addiction/get_existing_daeva_addiction.dm
@@ -1,5 +1,5 @@
 /datum/controller/subsystem/character_connection/proc/get_existing_daeva_addiction(mob/living/victim, mob/living/daeva)
-	if(!daeva || !victim || !daeva.ckey || !daeva.true_real_name || !victim.ckey || !victim.true_real_name)
+	if(!daeva || !victim || !daeva.ckey || !daeva.real_name || !victim.ckey || !victim.real_name)
 		return FALSE
 	var/datum/db_query/query = SSdbcore.NewQuery(
 		"SELECT \
@@ -21,13 +21,13 @@
 					character_name = :char_name_victim AND \
 					member_type = :member_type_victim AND \
 					date_ended IS NULL ) \
-		LIMIT 1", 
+		LIMIT 1",
 		list(
 			"ckey_daeva" = daeva.ckey,
-			"char_name_daeva" = daeva.true_real_name,
+			"char_name_daeva" = daeva.real_name,
 			"member_type_daeva" = MEMBER_TYPE_DAEVA_VAMPIRE,
 			"ckey_victim" = victim.ckey,
-			"char_name_victim" = victim.true_real_name,
+			"char_name_victim" = victim.real_name,
 			"member_type_victim" = MEMBER_TYPE_DAEVA_VICTIM,
 		)
 	)

--- a/code/modules/vtr13/connections/subsystems/SScharacter_connection_procs/db_operations/endorsements/check_can_endorse.dm
+++ b/code/modules/vtr13/connections/subsystems/SScharacter_connection_procs/db_operations/endorsements/check_can_endorse.dm
@@ -26,10 +26,10 @@
 			"ckey" = endorser.ckey,
 			"mem_type" = MEMBER_TYPE_ENDORSER,
 			"candidate_ckey" = candidate.ckey,
-			"candidate_name" = candidate.true_real_name
+			"candidate_name" = candidate.real_name
 		)
 	)
-	
+
 	if(!query.Execute(async = TRUE) || query.NextRow())
 		to_chat(endorser, span_notice("Your account is already endorsing this character."))
 		to_chat(candidate, span_notice("[endorser] cannot endorse you."))
@@ -51,7 +51,7 @@
 		LIMIT 1",
 		list(
 			"ckey" = endorser.ckey,
-			"char_name" = endorser.true_real_name,
+			"char_name" = endorser.real_name,
 			"mem_type" = MEMBER_TYPE_ENDORSER,
 			"grp_type" = connection_type
 		)
@@ -65,9 +65,9 @@
 	qdel(query_2)
 
 
-	
+
 	if(endorser_must_be_faction_head)
-		if(!SScharacter_connection.check_is_eligible_for_faction_head(endorser.ckey, endorser.true_real_name))
+		if(!SScharacter_connection.check_is_eligible_for_faction_head(endorser.ckey, endorser.real_name))
 			to_chat(endorser, span_notice("Your character cannot give this endorsement without being an eligible faction head for the Lancea et Sanctum, Ordo Dracul, Circle of the Crone, or the Carthian Movement."))
 			to_chat(candidate, span_notice("[endorser] cannot endorse you."))
 			return FALSE

--- a/code/modules/vtr13/connections/subsystems/SScharacter_connection_procs/db_operations/get_connection_by_group_id.dm
+++ b/code/modules/vtr13/connections/subsystems/SScharacter_connection_procs/db_operations/get_connection_by_group_id.dm
@@ -15,8 +15,8 @@
 			character_name = :char_name AND \
 			group_id = :grp_id \
 			date_ended IS NULL \
-		LIMIT 1", 
-		list("ckey" = target.ckey, "char_name" = target.true_real_name, "grp_id" = group_id)
+		LIMIT 1",
+		list("ckey" = target.ckey, "char_name" = target.real_name, "grp_id" = group_id)
 	)
 
 	if(!query.Execute(async = TRUE))
@@ -39,5 +39,5 @@
 		)
 
 	qdel(query)
-	
+
 	return connection

--- a/code/modules/vtr13/connections/subsystems/SScharacter_connection_procs/db_operations/insert_character_connection.dm
+++ b/code/modules/vtr13/connections/subsystems/SScharacter_connection_procs/db_operations/insert_character_connection.dm
@@ -12,12 +12,12 @@
 			INSERT INTO [format_table_name("character_connection")] (`group_id`, `group_type`, `member_type`, `player_ckey`, `character_name`, `connection_desc`, `round_id_established`, `date_established`, `hidden`)
 			VALUES (:group_id, :group_type, :member_type, :ckey, :char_name, :connection_desc, :round_id, Now(), :is_hidden)
 		"}, list(
-			"group_id" = our_group_id, 
-			"group_type" = group_type, 
-			"member_type" = member_type, 
-			"ckey" = target.ckey, 
-			"char_name" = target.true_real_name, 
-			"connection_desc" = connection_desc, 
+			"group_id" = our_group_id,
+			"group_type" = group_type,
+			"member_type" = member_type,
+			"ckey" = target.ckey,
+			"char_name" = target.real_name,
+			"connection_desc" = connection_desc,
 			"round_id" = GLOB.round_id,
 			"is_hidden" = hidden)
 	)

--- a/code/modules/vtr13/connections/subsystems/SScharacter_connection_verbs/offer_endorsement_verb.dm
+++ b/code/modules/vtr13/connections/subsystems/SScharacter_connection_verbs/offer_endorsement_verb.dm
@@ -6,7 +6,7 @@
 		CRASH("Offer endorsement called from a non living mob.")
 
 	var/mob/living/carbon/human/human_src = src
-	
+
 	if(human_src.has_status_effect(STATUS_EFFECT_REQUEST_CONNECTION))
 		return
 
@@ -19,11 +19,11 @@
 		if(endorsement_type.minimum_endorser_rank > human_src.vamp_rank)
 			continue
 		connection_selection += key
-	
+
 	//load head endorsement into the list
-	if(SScharacter_connection.check_is_eligible_for_faction_head(human_src.ckey, human_src.true_real_name))
+	if(SScharacter_connection.check_is_eligible_for_faction_head(human_src.ckey, human_src.real_name))
 		connection_selection += CONNECTION_ENDORSEMENT_FACTION_LEADER_SENESCHAL
-	
+
 	if(!length(connection_selection))
 		return
 

--- a/code/modules/vtr13/datums/vtr_bank_account.dm
+++ b/code/modules/vtr13/datums/vtr_bank_account.dm
@@ -21,7 +21,7 @@
 /datum/vtr_bank_account/proc/modify_balance(amount, mob/living/user = null)
 	if(!amount)
 		return TRUE
-	
+
 	if((-1 * amount) > balance)
 		if(user?.mind)
 			to_chat(user, span_alert("The transaction is declined - Insufficient funds."))
@@ -44,14 +44,14 @@
 
 
 /datum/vtr_bank_account/proc/process_credit_fraud(mob/living/carbon/human/user, stolen_amt)
-	if(!user || !user.mind || !user.true_real_name || !user.ckey)
+	if(!user || !user.mind || !user.real_name || !user.ckey)
 		return
-	
+
 	if(tracked_owner_mob)
 		var/mob/owner = tracked_owner_mob.resolve()
 		if(owner && user == owner)
 			return
-	
+
 	if(!credit_thieves)
 		credit_thieves = list()
 

--- a/code/modules/vtr13/disciplines/animalism/animalism_5_mark_territory.dm
+++ b/code/modules/vtr13/disciplines/animalism/animalism_5_mark_territory.dm
@@ -64,7 +64,11 @@
 		return
 
 	LAZYADD(notified_tresspassers_list, mover)
-	to_chat(owner, "You sense [mover] crossing your territorial line...")
+	if(istype(mover,/mob/living))
+		var/mob/living/player = mover
+		to_chat(owner, "You sense [player?.true_real_name ? player.true_real_name : player.real_name] crossing your territorial line...")
+	else
+		to_chat(owner, "You sense [mover] crossing your territorial line...")
 	addtimer(CALLBACK(src, PROC_REF(notify_timeout), mover), notify_cooldown)
 
 /datum/discipline_power/vtr/animalism/mark_territory/proc/notify_timeout(mob/mover)

--- a/code/modules/vtr13/disciplines/dominate/dominate_act/compel/say_your_true_name.dm
+++ b/code/modules/vtr13/disciplines/dominate/dominate_act/compel/say_your_true_name.dm
@@ -1,0 +1,8 @@
+/datum/dominate_act/compel/say_your_true_name
+	phrase = "Say your name."
+	activate_verb = "introduce yourself"
+	no_remove = TRUE
+
+/datum/dominate_act/compel/say_your_true_name/apply(mob/living/target)
+	..()
+	addtimer(CALLBACK(target, TYPE_PROC_REF(/atom/movable, say), "My name is [target?.true_real_name ? target.true_real_name : target.real_name]!"), 5)

--- a/code/modules/vtr13/mobs/human/memories/actions/memory_button.dm
+++ b/code/modules/vtr13/mobs/human/memories/actions/memory_button.dm
@@ -20,11 +20,11 @@
 
 /datum/action/memory_button/Topic(href, href_list)
 	if(href_list["delete_connection"])
-		
+
 		var/mob/living/living_owner = owner
 		if(!living_owner)
 			return
 
-		if(!SScharacter_connection.retire_connection(living_owner, living_owner.ckey, living_owner.true_real_name, text2num(href_list["delete_connection"])))
+		if(!SScharacter_connection.retire_connection(living_owner, living_owner.ckey, living_owner.real_name, text2num(href_list["delete_connection"])))
 			return
 		Trigger()

--- a/code/modules/vtr13/mobs/human/memories/components/base_memory.dm
+++ b/code/modules/vtr13/mobs/human/memories/components/base_memory.dm
@@ -52,7 +52,7 @@
 	dat += "<center><h2>Memories</h2></center>"
 
 	if(!(SEND_SIGNAL(src, COMSIG_MEMORY_NAME_OVERRIDE, owner, is_own_memories) & COMPONENT_MEMORY_OVERRIDE))
-		dat += "[icon2html(getFlatIcon(owner, SOUTH), owner)]I am [owner.true_real_name]."
+		dat += "[icon2html(getFlatIcon(owner, SOUTH), owner)]I am [owner.real_name]."
 	dat += "Tonight, I have taken the role of \a [owner.mind.assigned_role]."
 
 	if(is_own_memories && istype(owner, /mob/living/carbon/human))

--- a/code/modules/vtr13/mobs/human/memories/elements/ghoul_memory_modifier.dm
+++ b/code/modules/vtr13/mobs/human/memories/elements/ghoul_memory_modifier.dm
@@ -19,13 +19,13 @@
 	UnregisterSignal(source, COMSIG_MEMORY_NAME_OVERRIDE)
 	UnregisterSignal(source, COMSIG_MEMORY_SPLAT_TEXT)
 	UnregisterSignal(source, COMSIG_MEMORY_DISCIPLINE_TEXT)
-	
+
 
 
 /datum/element/ghoul_memory_modifier/proc/name_override(datum/source, mob/living/carbon/human/owner, is_own_memories)
 	SIGNAL_HANDLER
 	var/datum/component/base_memory/base_memory = source
-	base_memory.dat += "[icon2html(getFlatIcon(owner), owner)]I am [owner.true_real_name], a Ghoul."
+	base_memory.dat += "[icon2html(getFlatIcon(owner), owner)]I am [owner.real_name], a Ghoul."
 	return COMPONENT_MEMORY_OVERRIDE
 
 /datum/element/ghoul_memory_modifier/proc/splat_text(datum/source, mob/living/carbon/human/owner, is_own_memories)

--- a/code/modules/vtr13/mobs/human/memories/elements/kindred_memory_modifier.dm
+++ b/code/modules/vtr13/mobs/human/memories/elements/kindred_memory_modifier.dm
@@ -19,13 +19,13 @@
 	UnregisterSignal(source, COMSIG_MEMORY_NAME_OVERRIDE)
 	UnregisterSignal(source, COMSIG_MEMORY_SPLAT_TEXT)
 	UnregisterSignal(source, COMSIG_MEMORY_DISCIPLINE_TEXT)
-	
+
 
 
 /datum/element/kindred_memory_modifier/proc/name_override(datum/source, mob/living/carbon/human/owner, is_own_memories)
 	SIGNAL_HANDLER
 	var/datum/component/base_memory/base_memory = source
-	base_memory.dat += "[icon2html(getFlatIcon(owner), owner)]I am [owner.true_real_name], a Vampire of clan [owner.clane.name]."
+	base_memory.dat += "[icon2html(getFlatIcon(owner), owner)]I am [owner.real_name], a Vampire of clan [owner.clane.name]."
 	return COMPONENT_MEMORY_OVERRIDE
 
 /datum/element/kindred_memory_modifier/proc/splat_text(datum/source, mob/living/carbon/human/owner, is_own_memories)

--- a/code/modules/vtr13/mobs/living/refresh_character_connections.dm
+++ b/code/modules/vtr13/mobs/living/refresh_character_connections.dm
@@ -1,3 +1,3 @@
 /mob/living/proc/refresh_character_connections()
 	if(mind)
-		src.mind.character_connections = SScharacter_connection.get_character_connections(ckey, true_real_name)
+		src.mind.character_connections = SScharacter_connection.get_character_connections(ckey, real_name)

--- a/code/modules/vtr13/preferences/copy_to.dm
+++ b/code/modules/vtr13/preferences/copy_to.dm
@@ -27,7 +27,7 @@
 				real_name += "[pick(GLOB.last_names)]"
 
 	character.real_name = real_name
-	character.true_real_name = real_name
+	character.true_real_name = true_real_name
 	character.name = character.real_name
 	character.headshot_link = headshot_link
 

--- a/code/modules/vtr13/preferences/helper_procs/random_character.dm
+++ b/code/modules/vtr13/preferences/helper_procs/random_character.dm
@@ -5,6 +5,7 @@
 		random_species()
 	else if(randomise[RANDOM_NAME])
 		real_name = pref_species.random_name(gender,1)
+		true_real_name = real_name
 	if(gender_override && !(randomise[RANDOM_GENDER] || randomise[RANDOM_GENDER_ANTAG] && antag_override))
 		gender = gender_override
 	else

--- a/code/modules/vtr13/preferences/html_procs/character_settings_page.dm
+++ b/code/modules/vtr13/preferences/html_procs/character_settings_page.dm
@@ -10,6 +10,8 @@
 	dat += "<a href='byond://?_src_=prefs;preference=name;task=random'>Random Name</A> "
 	dat += "<br><b>Name:</b> "
 	dat += "<a href='byond://?_src_=prefs;preference=name;task=input'>[real_name]</a><BR>"
+	dat += "<br><b>True Name:</b> "
+	dat += "<a href='byond://?_src_=prefs;preference=true_name;task=input'>[true_real_name]</a><BR>"
 
 	if(!(AGENDER in pref_species.species_traits))
 		dat += "<b>Gender:</b> <a href='byond://?_src_=prefs;preference=gender'>[gender == MALE ? "Male" : gender == FEMALE ? "Female" : "Other"]</a>"
@@ -30,10 +32,10 @@
 	dat += "<b>Embracing Preference:</b> <a href='byond://?_src_=prefs;preference=ooc_embrace_pref;task=input'>[ooc_embrace_pref]</a><BR><BR>"
 	dat += "<b>Unprovoked Violence:</b> <a href='byond://?_src_=prefs;preference=ooc_escalation_pref;task=input'>[ooc_escalation_pref]</a>"
 	dat += "</td></tr></table>"
-	
+
 	dat += "<h2>[make_font_cool("Splat")]</h2>"
 
-	
+
 
 	dat += "<b>Splat:</b> <a href='?_src_=prefs;preference=species;task=input'>[pref_species.name]</a><BR>"
 	if(pref_species.name == "Vampire")
@@ -161,7 +163,7 @@
 			dat += "<b>Covenant: </b><a href='byond://?_src_=prefs;preference=vamp_faction;task=input'>[vamp_faction.name]</A><BR>"
 			dat += "<b>Description:</b> [vamp_faction.desc]<BR>"
 		dat += "</td></tr></table>"
-		
+
 	else if(pref_species.name == "Ghoul")
 		dat += "<table width='100%'><tr><td width='50%' valign='top'>"
 		dat += "<h2>[make_font_cool("CLAN")]</h2>"
@@ -190,7 +192,7 @@
 
 	dat += "</td>"
 	dat += "<td width ='20%' valign='top'>"
-	
+
 	dat += "<h2>[make_font_cool("EQUIP")]</h2>"
 
 	dat += "<b>Underwear:</b><BR><a href ='byond://?_src_=prefs;preference=underwear;task=input'>[underwear]</a>"

--- a/code/modules/vtr13/preferences/preferences_defines.dm
+++ b/code/modules/vtr13/preferences/preferences_defines.dm
@@ -162,6 +162,7 @@
 	var/info_known = INFO_KNOWN_UNKNOWN
 	var/gender = MALE					//gender of character (well duh)
 	var/real_name						//our character's name
+	var/true_real_name
 	var/body_type 						// Agendered spessmen can choose whether to have a male or female bodytype
 	var/age = 30						//biological age of character
 	var/flavor_text
@@ -262,6 +263,7 @@
 	key_bindings = deepCopyList(GLOB.hotkey_keybinding_list_by_key) // give them default keybinds and update their movement keys
 	C?.set_macros()
 	real_name = pref_species.random_name(gender,1)
+	true_real_name = real_name
 	if(!loaded_preferences_successfully)
 		save_preferences()
 	save_character()		//let's save this new random character so it doesn't keep generating new ones.

--- a/code/modules/vtr13/preferences/savfile_procs/_load_character.dm
+++ b/code/modules/vtr13/preferences/savfile_procs/_load_character.dm
@@ -37,6 +37,7 @@
 	real_name = reject_bad_name(real_name)
 	if(!real_name)
 		real_name = random_unique_name(gender)
+		true_real_name = real_name
 
 	READ_FILE(S["true_real_name"], true_real_name)
 	true_real_name = reject_bad_name(true_real_name)

--- a/code/modules/vtr13/preferences/savfile_procs/_load_character.dm
+++ b/code/modules/vtr13/preferences/savfile_procs/_load_character.dm
@@ -38,6 +38,11 @@
 	if(!real_name)
 		real_name = random_unique_name(gender)
 
+	READ_FILE(S["true_real_name"], true_real_name)
+	true_real_name = reject_bad_name(true_real_name)
+	if(!true_real_name)
+		true_real_name = real_name
+
 	READ_FILE(S["body_type"], body_type)
 	body_type = sanitize_gender(body_type, FALSE, FALSE, gender)
 

--- a/code/modules/vtr13/preferences/savfile_procs/_save_character.dm
+++ b/code/modules/vtr13/preferences/savfile_procs/_save_character.dm
@@ -13,6 +13,7 @@
 	WRITE_FILE(S["info_known"], info_known)
 	WRITE_FILE(S["gender"], gender)
 	WRITE_FILE(S["real_name"], real_name)
+	WRITE_FILE(S["true_real_name"], true_real_name)
 	WRITE_FILE(S["body_type"], body_type)
 	WRITE_FILE(S["age"], age)
 	WRITE_FILE(S["flavor_text"], flavor_text)
@@ -51,7 +52,7 @@
 	WRITE_FILE(S["wits"], get_wits(FALSE))
 	WRITE_FILE(S["resolve"], get_resolve(FALSE))
 	WRITE_FILE(S["potency"], get_potency(FALSE))
-	
+
 
 	WRITE_FILE(S["equipped_gear"], equipped_gear)
 

--- a/code/modules/vtr13/preferences/savfile_procs/save_file_version_handling.dm
+++ b/code/modules/vtr13/preferences/savfile_procs/save_file_version_handling.dm
@@ -9,5 +9,7 @@
 	return
 
 /datum/preferences/proc/update_character(current_version, savefile/S)
+	if(current_version <= 43)
+		true_real_name = real_name
 	return
 

--- a/code/modules/vtr13/preferences/topic_procs/process_input_task_links.dm
+++ b/code/modules/vtr13/preferences/topic_procs/process_input_task_links.dm
@@ -36,7 +36,7 @@
 
 //=======CHARACTER_PAGE=======
 		if("name")
-			if(real_name && alert(user, "WARNING: Changing your name will dissociate any existing character connections from this slot!", "WARNING", "Okay", "Cancel") == "Cancel")
+			if(real_name && alert(user, "WARNING: Changing your name will dissociate any existing character connections from this slot! You will need to ask an admin to reassign your connections if this is an in character change!", "WARNING", "Okay", "Cancel") == "Cancel")
 				return
 
 			var/new_name = tgui_input_text(user, "Choose your character's name:", "Character Preference", max_length = MAX_NAME_LEN)
@@ -53,6 +53,19 @@
 			if(new_name != real_name)
 				SScharacter_connection.retire_all_endorsements(user.ckey, real_name)
 				real_name = new_name
+
+		if("true_name")
+			var/new_true_name = tgui_input_text(user, "Choose your character's true name, if separate from their public-facing name:", "Character Preference", max_length = MAX_NAME_LEN)
+
+			if(!new_true_name)
+				new_true_name = real_name
+			new_true_name = reject_bad_name(new_true_name)
+
+			if(!new_true_name)
+				to_chat(user, "<font color='red'>Invalid name. Your name should be at least 2 and at most [MAX_NAME_LEN] characters long. It may only contain the characters A-Z, a-z, -, ' and . It must not contain any words restricted by IC chat and name filters.</font>")
+				return
+			if(new_true_name != true_real_name)
+				true_real_name = new_true_name
 
 		if("age")
 			var/new_age = tgui_input_number(user, "Choose your character's biological age:\n([AGE_MIN]-[AGE_MAX])", "Character Preference", age, AGE_MAX, AGE_MIN, round_value = TRUE)
@@ -250,7 +263,7 @@
 		if("decrease_stat")
 			var/datum/attribute/A = locate(href_list["attribute"])
 			A.score--
-		
+
 		if("increase_potency")
 			set_potency(get_potency() + 1)
 			adjust_blood_potency()
@@ -283,7 +296,7 @@
 				clane = new newtype()
 				vamp_rank = VAMP_RANK_NEONATE
 				adjust_blood_potency()
-				
+
 				all_merits.Cut()
 				merit_custom_settings.Cut()
 
@@ -303,7 +316,7 @@
 					vamp_faction = new /datum/vtr_faction/vamp_faction/unaligned()
 					vamp_rank = VAMP_RANK_HALF_DAMNED
 					adjust_blood_potency()
-				
+
 				if(clane.name == "Mekhet")
 					AddBanesUntilItIsDone()
 
@@ -408,7 +421,7 @@
 				vamp_rank = GLOB.vampire_rank_list[new_vamp_rank]
 			AddBanesUntilItIsDone()
 			adjust_blood_potency()
-		
+
 		if("vamp_faction")
 			if(clane?.name == "Revenant")
 				return
@@ -488,10 +501,10 @@
 			qdel(choose_species)
 
 			if(result && result != pref_species.id)
-				
+
 				all_merits.Cut()
 				merit_custom_settings.Cut()
-				
+
 				auspice_level = 0
 				qdel(clane)
 				clane = null

--- a/code/modules/vtr13/preferences/topic_procs/process_random_task_links.dm
+++ b/code/modules/vtr13/preferences/topic_procs/process_random_task_links.dm
@@ -6,6 +6,7 @@
 	switch(href_list["preference"])
 		if("name")
 			real_name = pref_species.random_name(gender,1)
+			true_real_name = real_name
 		if("all")
 			random_character(gender)
 	return TRUE

--- a/code/modules/wod13/items/blood_hunt.dm
+++ b/code/modules/wod13/items/blood_hunt.dm
@@ -18,7 +18,7 @@
 			reason = "No reason necessary."
 		var/name_in_list = FALSE
 		for(var/mob/living/carbon/human/H in GLOB.player_list)
-			if(H?.true_real_name == chosen_name)
+			if(H?.real_name == chosen_name)
 				if(H in SSbloodhunt.hunted)
 					if(HAS_TRAIT(src, TRAIT_HUNTED))
 						to_chat(user, span_warning("You can't remove [chosen_name] from the list!"))
@@ -29,7 +29,7 @@
 					to_chat(user, span_warning("You remove [chosen_name] from the Hunted list."))
 					for(var/mob/living/carbon/human/R in GLOB.player_list)
 						if(R && iskindred(R) && R.client)
-							to_chat(R, "<b>The Blood Hunt after <span class='green'>[H.true_real_name]</span> is over!</b>")
+							to_chat(R, "<b>The Blood Hunt after <span class='green'>[H.real_name]</span> is over!</b>")
 							SEND_SOUND(R, sound('code/modules/wod13/sounds/announce.ogg'))
 				else
 					SSbloodhunt.announce_hunted(H, reason)

--- a/code/modules/wod13/items/masquerade_contract.dm
+++ b/code/modules/wod13/items/masquerade_contract.dm
@@ -14,6 +14,6 @@
 		for(var/mob/living/carbon/human/H in GLOB.masquerade_breakers_list)
 			var/turf/TT = get_turf(H)
 			if(TT)
-				to_chat(user, "[H.true_real_name], Masquerade: [H.masquerade], last seen: [get_area_sector(H)]")
+				to_chat(user, "[H.real_name], Masquerade: [H.masquerade], last seen: [get_area_sector(H)]")
 	else
 		to_chat(user, "No available Masquerade breakers in city...")

--- a/code/modules/wod13/stonks.dm
+++ b/code/modules/wod13/stonks.dm
@@ -14,11 +14,11 @@
 	if(name == "unidentified stocks trading license")
 		if(ishuman(user))
 			var/mob/living/carbon/human/H = user
-			var/obj/item/stocks_license/CR = get_fuckin_card_number(H.true_real_name)
+			var/obj/item/stocks_license/CR = get_fuckin_card_number(H.real_name)
 			if(CR)
 				return
-			name = "[H.true_real_name]'s stocks trading license"
-			whose = H.true_real_name
+			name = "[H.real_name]'s stocks trading license"
+			whose = H.real_name
 
 /obj/item/stocks_license/Initialize()
 	. = ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3647,6 +3647,7 @@
 #include "code\modules\vtr13\disciplines\dominate\dominate_act\compel\break_it_down.dm"
 #include "code\modules\vtr13\disciplines\dominate\dominate_act\compel\clap.dm"
 #include "code\modules\vtr13\disciplines\dominate\dominate_act\compel\say_my_name.dm"
+#include "code\modules\vtr13\disciplines\dominate\dominate_act\compel\say_your_true_name.dm"
 #include "code\modules\vtr13\disciplines\dominate\dominate_act\compel\slow_down.dm"
 #include "code\modules\vtr13\disciplines\dominate\elements\compulsion.dm"
 #include "code\modules\vtr13\disciplines\dominate\subsystems\SSdominate_compulsion.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The true_real_name var already existed, making this much easier. All I did was set the character creator to allow one to be set and removed the instance of it being set to... just be their display name. I also went in and set animalism 5 to prioritize someone's true name if available instead of the displayed name. Compel now has the "Say your name" command. Please update the wiki accordingly when this is merged.

New character slots that haven't been named yet, when clicked, will put the previously selected slot's name into the input. I'm not sure exactly why but it doesn't do that to existing characters. Existing characters will load up with their normal name in their true name slot. Hitting randomize name applies the same randomized name to both boxes.

## Why It's Good For The Game

Maybe you don't want people to know your full name!

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="421" height="158" alt="dreamseeker_J7kEb8ryBn" src="https://github.com/user-attachments/assets/dbdc24a9-48b4-4c45-8bc5-c9c1a3690004" />
<img width="434" height="55" alt="dreamseeker_DsUmPW24yb" src="https://github.com/user-attachments/assets/ac8fcbf9-101b-4f8c-abfc-3109cc1116e2" />
<img width="365" height="51" alt="dreamseeker_H0Jd9coy3N" src="https://github.com/user-attachments/assets/f816b73b-2ff2-4580-beb6-21b8f01ba2b5" />
<img width="258" height="236" alt="4nHtz0LsqS" src="https://github.com/user-attachments/assets/c051824e-31b0-4f82-a613-8a7282ee5800" />


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Compel can now demand someone to announce their true name
code: True name is now a separate var that players can set in their save files.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
