### PR TITLE
police station mag fixes

### DIFF
--- a/_maps/map_files/Vampire/LongBeachPractice.dmm
+++ b/_maps/map_files/Vampire/LongBeachPractice.dmm
@@ -2737,7 +2737,7 @@
 /obj/item/storage/firstaid/regular,
 /obj/item/ammo_box/vampire/c45acp,
 /obj/item/gun/ballistic/automatic/vampire/m1911,
-/obj/item/ammo_box/magazine/m45,
+/obj/item/ammo_box/magazine/vamp45acp,
 /turf/open/floor/plating/vampplating,
 /area/vtm/vtr/masquerade/interior/floor_two/northwest/police_station)
 "clh" = (
@@ -6354,7 +6354,7 @@
 /obj/item/storage/firstaid/regular,
 /obj/item/gun/ballistic/automatic/vampire/m1911,
 /obj/item/ammo_box/vampire/c45acp,
-/obj/item/ammo_box/magazine/m45,
+/obj/item/ammo_box/magazine/vamp45acp,
 /turf/open/floor/plating/vampplating,
 /area/vtm/vtr/masquerade/interior/floor_two/northwest/police_station)
 "ffL" = (
@@ -13691,9 +13691,9 @@
 /obj/item/camera/detective,
 /obj/item/clipboard,
 /obj/item/clipboard,
-/obj/item/ammo_box/magazine/m45,
-/obj/item/ammo_box/magazine/m45,
-/obj/item/ammo_box/magazine/m45,
+/obj/item/ammo_box/magazine/vamp45acp,
+/obj/item/ammo_box/magazine/vamp45acp,
+/obj/item/ammo_box/magazine/vamp45acp,
 /turf/open/floor/plating/parquetry,
 /area/vtm/vtr/masquerade/interior/ground_floor/northwest/police_station)
 "lxo" = (
@@ -25388,8 +25388,8 @@
 	pixel_y = 0
 	},
 /obj/item/clipboard,
-/obj/item/ammo_box/magazine/m45,
-/obj/item/ammo_box/magazine/m45,
+/obj/item/ammo_box/magazine/vamp45acp,
+/obj/item/ammo_box/magazine/vamp45acp,
 /turf/open/floor/plating/parquetry,
 /area/vtm/vtr/masquerade/interior/ground_floor/northwest/police_station)
 "uEp" = (


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

changes the mags intended for the 1911s in the police station from the wrong type (m45 mag?) to the correct type (vamp45acp)

## Why It's Good For The Game

means the police station has the proper gun mags so i dont have to drop the mags from the other colts just to have >1 magazine at a time

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>n/a</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
map: changed mags in police station lockers & office closet to the correct ones (vamp45acp)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
