### PR TITLE
add it/its pronouns as an option

### DIFF
--- a/code/__HELPERS/sanitize_values.dm
+++ b/code/__HELPERS/sanitize_values.dm
@@ -48,20 +48,14 @@
 			. += value
 
 //more specialised stuff
-/proc/sanitize_gender(gender,neuter=0,plural=1, default="male")
+/proc/sanitize_gender(gender, default="plural")
 	switch(gender)
 		if(MALE, FEMALE)
 			return gender
-		if(NEUTER)
-			if(neuter)
-				return gender
-			else
-				return default
 		if(PLURAL)
-			if(plural)
-				return gender
-			else
-				return default
+			return gender
+		if(NEUTER)
+			return gender
 	return default
 
 /proc/sanitize_hexcolor(color, desired_format = DEFAULT_HEX_COLOR_LEN, include_crunch = FALSE, default)

--- a/code/modules/vtr13/preferences/savfile_procs/_load_character.dm
+++ b/code/modules/vtr13/preferences/savfile_procs/_load_character.dm
@@ -45,7 +45,7 @@
 		true_real_name = real_name
 
 	READ_FILE(S["body_type"], body_type)
-	body_type = sanitize_gender(body_type, FALSE, FALSE, gender)
+	body_type = sanitize_gender(body_type)
 
 	READ_FILE(S["age"], age)
 	age = sanitize_integer(age, AGE_MIN, AGE_MAX, initial(age))

--- a/code/modules/vtr13/preferences/topic_procs/process_misc_task_links.dm
+++ b/code/modules/vtr13/preferences/topic_procs/process_misc_task_links.dm
@@ -5,7 +5,7 @@
 
 	switch(href_list["preference"])
 		if("gender")
-			var/list/friendlyGenders = list("Masculine (He/Him)" = "male", "Feminine (She/Her)" = "female", "Other (They/Them)" = "plural")
+			var/list/friendlyGenders = list("Masculine (He/Him)" = "male", "Feminine (She/Her)" = "female", "Neutral (They/Them)" = "plural", "Other (It/Its)" = "neuter")
 			var/pickedGender = tgui_input_list(user, "Choose your gender.", "Character Preference", friendlyGenders, gender)
 			if(pickedGender && friendlyGenders[pickedGender] != gender)
 				gender = friendlyGenders[pickedGender]
@@ -285,7 +285,7 @@
 		if("changeslot")
 			if(merit_sub_tab==PREFS_BANES_SUB_TAB)
 				merit_sub_tab = PREFS_MERITS_SUB_TAB
-			
+
 			if(!load_character(text2num(href_list["num"])))
 				reset_character()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds "it/it/its" as a selectable pronoun set.

## Why It's Good For The Game

Many characters regularly played on the server use it/its pronouns. There are many reasons someone might want their character to be labelled with "it" instead of more specific pronouns.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="421" height="144" alt="image" src="https://github.com/user-attachments/assets/eb3dc714-293b-4cae-ac9a-b2683a88013c" />


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: it/it/its pronouns are now selectable in character setup
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
