### PR TITLE
update date on endorsements

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -561,6 +561,7 @@
 					if(LM)
 						H.forceMove(LM.loc)
 			H.refresh_character_connections()
+			SScharacter_connection.update_date_on_endorsements(H.ckey, H.real_name)
 		new_character = null
 		qdel(src)
 

--- a/code/modules/vtr13/connections/subsystems/SScharacter_connection_procs/db_operations/endorsements/update_date_on_endorsements.dm
+++ b/code/modules/vtr13/connections/subsystems/SScharacter_connection_procs/db_operations/endorsements/update_date_on_endorsements.dm
@@ -1,0 +1,25 @@
+/datum/controller/subsystem/character_connection/proc/update_date_on_endorsements(ckey, character_name)
+	//Update all non-expired connections
+	var/datum/db_query/query_update = SSdbcore.NewQuery(
+		"UPDATE [format_table_name("character_connection")] \
+		SET date_established = Now() \
+		WHERE \
+			group_id IN ( \
+				SELECT group_id \
+				FROM [format_table_name("character_connection")] \
+				WHERE \
+					member_type = :mem_type AND \
+					date_ended IS NULL AND \
+					player_ckey = :ckey AND \
+					character_name = :c_name AND \
+					date_ended IS NULL\
+			)",
+		list(
+			"mem_type" = MEMBER_TYPE_ENDORSER,
+			"stale_offset" = ENDORSEMENT_STALE_OFFSET_MONTHS,
+			"ckey" = ckey,
+			"c_name" = character_name
+		)
+	)
+	query_update.Execute()
+	qdel(query_update)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3598,6 +3598,7 @@
 #include "code\modules\vtr13\connections\subsystems\SScharacter_connection_procs\db_operations\endorsements\check_can_endorse.dm"
 #include "code\modules\vtr13\connections\subsystems\SScharacter_connection_procs\db_operations\endorsements\check_is_eligible_for_faction_head.dm"
 #include "code\modules\vtr13\connections\subsystems\SScharacter_connection_procs\db_operations\endorsements\get_eligable_faction_head_roles.dm"
+#include "code\modules\vtr13\connections\subsystems\SScharacter_connection_procs\db_operations\endorsements\update_date_on_endorsements.dm"
 #include "code\modules\vtr13\connections\subsystems\SScharacter_connection_procs\db_operations\endorsements\update_retire_all_endorsements.dm"
 #include "code\modules\vtr13\connections\subsystems\SScharacter_connection_procs\db_operations\endorsements\update_retire_all_stale_endorsements.dm"
 #include "code\modules\vtr13\connections\subsystems\SScharacter_connection_verbs\offer_boon_verb.dm"


### PR DESCRIPTION
Prevents endorsements from retiring by playing with the endorsing character for any amount of time.