### PR TITLE
Adds more masks to loadout options, allows select masks to be worn below the hair

### DIFF
--- a/code/modules/clothing/masks/animal_masks.dm
+++ b/code/modules/clothing/masks/animal_masks.dm
@@ -15,7 +15,7 @@ GLOBAL_LIST_INIT(cursed_animal_masks, list(
 
 /obj/item/clothing/mask/animal
 	w_class = WEIGHT_CLASS_SMALL
-	clothing_flags = VOICEBOX_TOGGLABLE
+	clothing_flags = VOICEBOX_DISABLED
 	modifies_speech = TRUE
 	flags_cover = MASKCOVERSMOUTH
 

--- a/code/modules/vtr13/preferences/loadouts/gear/loadout_masks.dm
+++ b/code/modules/vtr13/preferences/loadouts/gear/loadout_masks.dm
@@ -16,10 +16,66 @@
 	display_name = "balaclava"
 	path = /obj/item/clothing/mask/vampire/balaclava
 
+/datum/gear/mask/venetian
+	display_name = "venetian mask"
+	path = /obj/item/clothing/mask/vampire/venetian_mask
+
+/datum/gear/mask/venetian_fancy
+	display_name = "gilded venetian mask"
+	path = /obj/item/clothing/mask/vampire/venetian_mask/fancy
+
+/datum/gear/mask/venetian_bloody
+	display_name = "bloodied mask"
+	path = /obj/item/clothing/mask/vampire/venetian_mask/scary
+
+/datum/gear/mask/jester
+	display_name = "jester mask"
+	path = /obj/item/clothing/mask/vampire/venetian_mask/jester
+
 /datum/gear/mask/shemagh
 	display_name = "shemagh"
 	path = /obj/item/clothing/mask/vampire/shemagh
 
+/datum/gear/mask/tragedy
+	display_name = "tragic mask"
+	path = /obj/item/clothing/mask/vampire/tragedy
+
+/datum/gear/mask/comedy
+	display_name = "comedic mask"
+	path = /obj/item/clothing/mask/vampire/comedy
+
 /datum/gear/mask/bee_mask
-	display_name = "bee mask"
+	display_name = "animal mask, bee"
 	path = /obj/item/clothing/mask/animal/rat/bee
+
+/datum/gear/mask/pig_mask
+	display_name = "animal mask, pig"
+	path = /obj/item/clothing/mask/animal/pig
+
+/datum/gear/mask/fox_mask
+	display_name = "animal mask, fox"
+	path = /obj/item/clothing/mask/animal/rat/fox
+
+/datum/gear/mask/bear_mask
+	display_name = "animal mask, bear"
+	path = /obj/item/clothing/mask/animal/rat/bear
+
+/datum/gear/mask/rat_mask
+	display_name = "animal mask, rat"
+	path = /obj/item/clothing/mask/animal/rat
+
+/datum/gear/mask/horse_mask
+	display_name = "animal mask, horse"
+	path = /obj/item/clothing/mask/animal/horsehead
+
+/datum/gear/mask/bat_mask
+	display_name = "animal mask, bat"
+	path = /obj/item/clothing/mask/animal/rat/bat
+
+/datum/gear/mask/raven_mask
+	display_name = "animal mask, raven"
+	path = /obj/item/clothing/mask/animal/rat/raven
+
+/datum/gear/mask/jackal_mask
+	display_name = "animal mask, jackal"
+	path = /obj/item/clothing/mask/animal/rat/jackal

--- a/code/modules/wod13/items/clothes/mask.dm
+++ b/code/modules/wod13/items/clothes/mask.dm
@@ -13,6 +13,16 @@
 	flags_cover = MASKCOVERSMOUTH | PEPPERPROOF
 	resistance_flags = NONE
 	body_worn = TRUE
+	var/allow_refit = TRUE
+
+/obj/item/clothing/mask/vampire/AltClick(mob/user)
+	..()
+	if(alternate_worn_layer != GLASSES_LAYER && allow_refit)
+		to_chat(user, "<span class='warning'>You re-fit the mask to not cover your hair.</span>")
+		alternate_worn_layer = GLASSES_LAYER
+	else if(allow_refit)
+		to_chat(user, "<span class='warning'>You re-fit the mask to wear it over your hair.</span>")
+		alternate_worn_layer = initial(alternate_worn_layer)
 
 /obj/item/clothing/mask/vampire/balaclava
 	name = "balaclava"
@@ -22,6 +32,7 @@
 	flags_inv = HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 	visor_flags_inv = HIDEFACE|HIDEFACIALHAIR|HIDESNOUT
 	w_class = WEIGHT_CLASS_SMALL
+	allow_refit = FALSE
 
 /obj/item/clothing/mask/pentex/pentex_balaclava
 	name = "Thick balaclava"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Animal masks, comedy/tragedy masks, and all Venetian mask variants can be selected in the loadout. Additionally, all masks of the vampire suptype (excluding the balaclava) can be toggled with alt-click to display on the same layer as glasses, letting hair render over them.
Also toggles off the voiceboxes in animal masks by default, as it's a bit of a TG-style leftover mechanic.

## Why It's Good For The Game

- All of these masks are readily available at stores in-game. 
- Some hairstyles look good with the masks we have, but some don't look as good. It's just an aesthetic option for players to have their hair dramatically frame their mask.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: most VtR/VtM masks can be toggled to display over or under your hair with Alt Click
add: added most animal/vampire masks to the loadout
balance: animal masks no longer make you make animal noises at random (by default)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
