### PR TITLE
Adds Call Stoplight Verb

### DIFF
--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -494,3 +494,33 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 	set hidden = TRUE
 
 	init_verbs()
+
+/client/verb/call_stoplight()
+	set name = "Call Stoplight"
+	set category = "OOC"
+
+	if(!mob || isobserver(usr) || isnewplayer(usr))
+		to_chat(usr, "You must be a participant in the round to use the stoplight button.")
+		return
+
+	var selection = input("Announce a stoplight color to players around you to slow or halt the scene.", "Stoplight", "Cancel") in list("Red", "Yellow", "Green", "Cancel")
+
+	if(!selection)
+		return
+
+	switch(selection)
+		if("Red")
+			message_admins("[mob.name] has called a RED. [ADMIN_JMP(usr.loc)]")
+			for(var/mob/L in viewers(9, mob))
+				if(L.client)
+					to_chat(L, span_userdanger("[mob.name] has called RED. Halt the scene."))
+		if("Yellow")
+			for(var/mob/L in viewers(9, mob))
+				if(L.client)
+					to_chat(L, span_warning("[mob.name] has called YELLOW. Slow scene for LOOC discussion."))
+		if("Green")
+			for(var/mob/L in viewers(9, mob))
+				if(L.client)
+					to_chat(L, span_nicegreen("[mob.name] has confirmed GREEN. Please ensure all participants have agreed."))
+		if("Cancel")
+			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a verb in the OOC tab to "Call Stoplight". Provides all 3 colors and, in the same range as LOOC, displays an alert in varying intensity according to the color picked. This prevents stoplights from being missed. Red calls will also now alert admins and provide them a button to instantly jump to the call and monitor the situation.

Observers and those in lobby are unable to use this button.

## Why It's Good For The Game

Player safety.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="497" height="128" alt="dreamseeker_F8w5KMELxk" src="https://github.com/user-attachments/assets/c93fdc9a-f244-41f8-95cd-4386730c42d5" />


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Stoplight verb added
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
