### PR TITLE
Selectable character descriptors shown on examine

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -132,8 +132,8 @@
 
 	//VTR EDIT BEGIN
 	var/ooc_link
-	var/adjective
-	var/descriptor
+	var/custom_desc
+	var/custom_noun
 	var/datum/vtr_faction/vtr_faction
 	var/datum/vampireclane/clane
 	var/datum/vampireclane/regent_clan

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -132,6 +132,8 @@
 
 	//VTR EDIT BEGIN
 	var/ooc_link
+	var/adjective
+	var/descriptor
 	var/datum/vtr_faction/vtr_faction
 	var/datum/vampireclane/clane
 	var/datum/vampireclane/regent_clan

--- a/code/modules/vtr13/mobs/human/examine/examine_title.dm
+++ b/code/modules/vtr13/mobs/human/examine/examine_title.dm
@@ -6,59 +6,12 @@
 		if(HAS_TRAIT(L, TRAIT_PROSOPAGNOSIA))
 			obscure_name = TRUE
 
-	var/my_gender = "male"
-	switch(gender)
-		if(MALE)
-			switch(age)
-				if(16 to 24)
-					my_gender = "guy"
-				if(24 to INFINITY)
-					my_gender = "man"
-		if(FEMALE)
-			my_gender = "female"
-			switch(age)
-				if(16 to 24)
-					my_gender = "lady"
-				if(24 to INFINITY)
-					my_gender = "woman"
-		if(PLURAL, NEUTER)
-			my_gender = "person"
 
-	var/social_descriptor = "godlike"
+	var/shown_adjective = adjective
+	var/shown_descriptor = descriptor
+
 	if(!is_face_visible())
-		social_descriptor = "shrouded"
-	else
-		switch(get_charisma())
-			if(1)
-				social_descriptor = "unappealing"
-			if(2)
-				social_descriptor = "average"
-			if(3)
-				social_descriptor = "charming"
-			if(4)
-				social_descriptor = (gender == MALE)?"handsome" : "beautiful"
-			if(5)
-				social_descriptor = "gorgeous"
-
-	var/physical_descriptor = "inhuman"
-	switch(get_physique())
-		if(1)
-			physical_descriptor = "unathletic"
-		if(2)
-			physical_descriptor = "average"
-		if(3)
-			physical_descriptor = "toned"
-		if(4)
-			physical_descriptor = "muscular"
-		if(5)
-			physical_descriptor = "hulking"
-
-
-	var/total_descriptor
-	if(social_descriptor == physical_descriptor)
-		total_descriptor = physical_descriptor
-	else
-		total_descriptor = "[social_descriptor], [physical_descriptor]"
+		shown_adjective = "a shrouded"
 
 	var/cleanliness_note = ""
 	if(get_composure() <= 1)
@@ -66,4 +19,4 @@
 	if(get_composure() >= 5)
 		cleanliness_note = " [p_they(TRUE)] [p_are()] immaculately well put-together."
 
-	return "This is <EM>[!obscure_name ? name : "Unknown"]</EM>, \a [total_descriptor] [my_gender]![cleanliness_note]"
+	return "This is <EM>[!obscure_name ? name : "Unknown"]</EM>, [shown_descriptor] [shown_adjective]![cleanliness_note]"

--- a/code/modules/vtr13/mobs/human/examine/examine_title.dm
+++ b/code/modules/vtr13/mobs/human/examine/examine_title.dm
@@ -7,8 +7,8 @@
 			obscure_name = TRUE
 
 
-	var/shown_adjective = adjective
-	var/shown_descriptor = descriptor
+	var/shown_adjective = custom_desc
+	var/shown_descriptor = custom_noun
 
 	if(!is_face_visible())
 		shown_adjective = "a shrouded"
@@ -19,4 +19,4 @@
 	if(get_composure() >= 5)
 		cleanliness_note = " [p_they(TRUE)] [p_are()] immaculately well put-together."
 
-	return "This is <EM>[!obscure_name ? name : "Unknown"]</EM>, [shown_descriptor] [shown_adjective]![cleanliness_note]"
+	return "This is <EM>[!obscure_name ? name : "Unknown"]</EM>, [shown_adjective] [shown_descriptor]![cleanliness_note]"

--- a/code/modules/vtr13/mobs/human/examine/examine_title.dm
+++ b/code/modules/vtr13/mobs/human/examine/examine_title.dm
@@ -13,10 +13,4 @@
 	if(!is_face_visible())
 		shown_adjective = "a shrouded"
 
-	var/cleanliness_note = ""
-	if(get_composure() <= 1)
-		cleanliness_note = " [p_they(TRUE)] seems disheveled."
-	if(get_composure() >= 5)
-		cleanliness_note = " [p_they(TRUE)] [p_are()] immaculately well put-together."
-
-	return "This is <EM>[!obscure_name ? name : "Unknown"]</EM>, [shown_adjective] [shown_descriptor]![cleanliness_note]"
+	return "This is <EM>[!obscure_name ? name : "Unknown"]</EM>, [shown_adjective] [shown_descriptor]!"

--- a/code/modules/vtr13/preferences/copy_to.dm
+++ b/code/modules/vtr13/preferences/copy_to.dm
@@ -75,8 +75,8 @@
 
 	character.flavor_text = sanitize_text(flavor_text)
 	character.ooc_notes = sanitize_text(ooc_notes)
-	character.adjective = adjective
-	character.descriptor = descriptor
+	character.custom_desc = custom_desc
+	character.custom_noun = custom_noun
 	character.gender = gender
 	character.age = age
 	character.chronological_age = actual_age

--- a/code/modules/vtr13/preferences/copy_to.dm
+++ b/code/modules/vtr13/preferences/copy_to.dm
@@ -75,6 +75,8 @@
 
 	character.flavor_text = sanitize_text(flavor_text)
 	character.ooc_notes = sanitize_text(ooc_notes)
+	character.adjective = adjective
+	character.descriptor = descriptor
 	character.gender = gender
 	character.age = age
 	character.chronological_age = actual_age

--- a/code/modules/vtr13/preferences/descriptions/compile_desc_terms.dm
+++ b/code/modules/vtr13/preferences/descriptions/compile_desc_terms.dm
@@ -1,0 +1,20 @@
+/datum/preferences/proc/compile_adjectives(mob/user)
+	var/list/desc_master = list(list("a dreary","a messy", "an ugly", "a creepy", "a clumsy", "a graceless", "a strange", "a weird", "an odd", "a bizarre", "a freakish", "a nasty", "a gross", "an unappealing", "an unsettling", "a disturbing", "an off-putting", "an awful", "a desperate", "a crestfallen", "a haggard"),
+		list("a normal", "an ordinary", "a plain", "a regular", "a simple", "a typical", "an everyday", "an average", "an unremarkable", "a basic", "a middling", "a quiet", "a loud", "a reserved", "a bland", "a boring", "a forgettable", "a meek", "a gruff", "a grim", "a rugged", "a stern", "a scrappy", "an eerie"),
+		list("a warm", "an affable", "an agreeable", "a friendly","an attractive", "a charming", "a cute", "a pretty", "a neat", "a pleasant", "a stylish", "a well-groomed", "a put-together", "a sharp", "an intimidating", "a scary", "a cold"),
+		list("a sexy", "a refined", "a beautiful", "a handsome", "a hot", "a lovely", "an elegant", "a graceful", "a dashing", "a dapper", "a classy", "a foxy", "a suave", "a tasteful", "a darling", "a striking", "a terrifying", "a daunting", "an adorable", "a delightful"),
+		list("a gorgeous", "an exquisite", "a breath-taking", "a stunning", "a glamourous", "an immaculate", "an unflappable", "a regal", "a magnificent", "a majestic", "an unforgettable", "a horrifying", "a statuesque"),
+		list("an unearthly", "an impossible", "an incomparable", "a transcendent", "a peerless", "an otherworldly", "a divine", "a godlike", "an ethereal", "a perfect", "an angelic", "a demonic", "a devilish", "a hellish", "the"))
+	var/real_cha = stats.get_stat(STAT_CHARISMA)
+	var/list/available_adj = list("a", "an")
+	if(merit_custom_settings["expertise_stat"] == "Charisma")
+		real_cha += 1
+	for(var/i = 1; i <= real_cha; i++)
+		available_adj += desc_master[i]
+	return available_adj
+
+
+/datum/preferences/proc/compile_nouns(mob/user) //Not level-specific yet, but here to keep all of the descriptor lists in one place
+	var/list/noun_master = list("person", "man", "woman", "dude", "lady", "matron", "patron", "maiden", "youth", "senior", "gentleman", "gentleperson", "gentlewoman", "bloke", "guy", "dame", "diva", "doll", "tomboy", "butch", "femme", "futch", "bear", "twink", "waif", "wastrel", "wretch", "scoundrel", "vagrant", "vagabond", "bastard", "bitch", "sinner", "freak", "creature", "critter", "beast", "thing", "goth", "emo", "punk", "hipster", "nerd", "geek", "bro", "gal", "ditz", "jock", "prep", "individual", "figure")
+	return noun_master
+

--- a/code/modules/vtr13/preferences/descriptions/compile_desc_terms.dm
+++ b/code/modules/vtr13/preferences/descriptions/compile_desc_terms.dm
@@ -2,7 +2,7 @@
 	var/list/desc_master = list(list("a dreary","a messy", "an ugly", "a creepy", "a clumsy", "a graceless", "a strange", "a weird", "an odd", "a bizarre", "a freakish", "a nasty", "a gross", "an unappealing", "an unsettling", "a disturbing", "an awful", "a desperate", "a crestfallen", "a haggard"),
 		list("a normal", "an ordinary", "a plain", "a regular", "a simple", "a typical", "an everyday", "an average", "an unremarkable", "a basic", "a middling", "a quiet", "a loud", "a reserved", "a bland", "a boring", "a forgettable", "a meek", "a gruff", "a grim", "a rugged", "a stern", "a scrappy", "an eerie"),
 		list("a warm", "an affable", "an agreeable", "a friendly","an attractive", "a charming", "a cute", "a pretty", "a neat", "a pleasant", "a stylish", "a well-groomed", "a put-together", "a sharp", "an intimidating", "a scary", "a cold"),
-		list("a sexy", "a refined", "a beautiful", "a handsome", "a hot", "a lovely", "an elegant", "a graceful", "a dashing", "a dapper", "a classy", "a foxy", "a suave", "a tasteful", "a darling", "a striking", "a terrifying", "a daunting", "an adorable", "a delightful"),
+		list("a sexy", "a refined", "a beautiful", "a handsome", "a hot", "a lovely", "an elegant", "a graceful", "a dashing", "a dapper", "a classy", "a foxy", "a suave", "a tasteful", "a darling", "a striking", "a terrifying", "a daunting", "an adorable", "a delightful", "a dangerous", "a deadly"),
 		list("a gorgeous", "an exquisite", "a breath-taking", "a stunning", "a glamourous", "an immaculate", "an unflappable", "a regal", "a magnificent", "a majestic", "an unforgettable", "a horrifying", "a statuesque"),
 		list("an unearthly", "an impossible", "an incomparable", "a transcendent", "a peerless", "an otherworldly", "a divine", "a godlike", "an ethereal", "a perfect", "an angelic", "a demonic", "a devilish", "a hellish", "the"))
 	var/real_cha = stats.get_stat(STAT_CHARISMA)
@@ -15,6 +15,6 @@
 
 
 /datum/preferences/proc/compile_nouns(mob/user) //Not level-specific yet, but here to keep all of the descriptor lists in one place
-	var/list/noun_master = list("person", "man", "woman", "dude", "lady", "matron", "patron", "maiden", "youth", "senior", "gentleman", "gentleperson", "gentlewoman", "bloke", "presence", "show-off", "guy", "dame", "diva", "doll", "chick", "tomboy", "butch", "femme", "futch", "bear", "twink", "waif", "wastrel", "wretch", "scoundrel", "vagrant", "vagabond", "fella", "bastard", "bitch", "sinner", "freak", "creature", "critter", "hard-ass", "beast", "thing", "goth", "emo", "punk", "hipster", "nerd", "geek", "bro", "gal", "ditz", "jock", "prep", "individual", "figure")
+	var/list/noun_master = list("person", "man", "woman", "dude", "lady", "matron", "patron", "maiden", "youth", "senior", "gentleman", "gentleperson", "gentlewoman", "bloke", "presence", "show-off", "guy", "dame", "diva", "doll", "chick", "tomboy", "butch", "femme", "futch", "bear", "twink", "waif", "wastrel", "wretch", "scoundrel", "vagrant", "vagabond", "fella", "bastard", "bitch", "sinner", "freak", "creature", "critter", "hard-ass", "beast", "thing", "goth", "emo", "punk", "hipster", "nerd", "geek", "bro", "gal", "ditz", "jock", "prep", "individual", "figure", "nobody")
 	return noun_master
 

--- a/code/modules/vtr13/preferences/descriptions/compile_desc_terms.dm
+++ b/code/modules/vtr13/preferences/descriptions/compile_desc_terms.dm
@@ -1,12 +1,12 @@
 /datum/preferences/proc/compile_adjectives(mob/user)
-	var/list/desc_master = list(list("a dreary","a messy", "an ugly", "a creepy", "a clumsy", "a graceless", "a strange", "a weird", "an odd", "a bizarre", "a freakish", "a nasty", "a gross", "an unappealing", "an unsettling", "a disturbing", "an off-putting", "an awful", "a desperate", "a crestfallen", "a haggard"),
+	var/list/desc_master = list(list("a dreary","a messy", "an ugly", "a creepy", "a clumsy", "a graceless", "a strange", "a weird", "an odd", "a bizarre", "a freakish", "a nasty", "a gross", "an unappealing", "an unsettling", "a disturbing", "an awful", "a desperate", "a crestfallen", "a haggard"),
 		list("a normal", "an ordinary", "a plain", "a regular", "a simple", "a typical", "an everyday", "an average", "an unremarkable", "a basic", "a middling", "a quiet", "a loud", "a reserved", "a bland", "a boring", "a forgettable", "a meek", "a gruff", "a grim", "a rugged", "a stern", "a scrappy", "an eerie"),
 		list("a warm", "an affable", "an agreeable", "a friendly","an attractive", "a charming", "a cute", "a pretty", "a neat", "a pleasant", "a stylish", "a well-groomed", "a put-together", "a sharp", "an intimidating", "a scary", "a cold"),
 		list("a sexy", "a refined", "a beautiful", "a handsome", "a hot", "a lovely", "an elegant", "a graceful", "a dashing", "a dapper", "a classy", "a foxy", "a suave", "a tasteful", "a darling", "a striking", "a terrifying", "a daunting", "an adorable", "a delightful"),
 		list("a gorgeous", "an exquisite", "a breath-taking", "a stunning", "a glamourous", "an immaculate", "an unflappable", "a regal", "a magnificent", "a majestic", "an unforgettable", "a horrifying", "a statuesque"),
 		list("an unearthly", "an impossible", "an incomparable", "a transcendent", "a peerless", "an otherworldly", "a divine", "a godlike", "an ethereal", "a perfect", "an angelic", "a demonic", "a devilish", "a hellish", "the"))
 	var/real_cha = stats.get_stat(STAT_CHARISMA)
-	var/list/available_adj = list("a", "an")
+	var/list/available_adj = list("an off-putting")
 	if(merit_custom_settings["expertise_stat"] == "Charisma")
 		real_cha += 1
 	for(var/i = 1; i <= real_cha; i++)
@@ -15,6 +15,6 @@
 
 
 /datum/preferences/proc/compile_nouns(mob/user) //Not level-specific yet, but here to keep all of the descriptor lists in one place
-	var/list/noun_master = list("person", "man", "woman", "dude", "lady", "matron", "patron", "maiden", "youth", "senior", "gentleman", "gentleperson", "gentlewoman", "bloke", "guy", "dame", "diva", "doll", "tomboy", "butch", "femme", "futch", "bear", "twink", "waif", "wastrel", "wretch", "scoundrel", "vagrant", "vagabond", "bastard", "bitch", "sinner", "freak", "creature", "critter", "beast", "thing", "goth", "emo", "punk", "hipster", "nerd", "geek", "bro", "gal", "ditz", "jock", "prep", "individual", "figure")
+	var/list/noun_master = list("person", "man", "woman", "dude", "lady", "matron", "patron", "maiden", "youth", "senior", "gentleman", "gentleperson", "gentlewoman", "bloke", "presence", "show-off", "guy", "dame", "diva", "doll", "chick", "tomboy", "butch", "femme", "futch", "bear", "twink", "waif", "wastrel", "wretch", "scoundrel", "vagrant", "vagabond", "fella", "bastard", "bitch", "sinner", "freak", "creature", "critter", "hard-ass", "beast", "thing", "goth", "emo", "punk", "hipster", "nerd", "geek", "bro", "gal", "ditz", "jock", "prep", "individual", "figure")
 	return noun_master
 

--- a/code/modules/vtr13/preferences/html_procs/character_settings_page.dm
+++ b/code/modules/vtr13/preferences/html_procs/character_settings_page.dm
@@ -188,10 +188,11 @@
 	if(headshot_link != null)
 		dat += " <a href='byond://?_src_=prefs;preference=view_headshot;task=input'>View</a>"
 	dat += "<br><br>"
-	dat += "<b>Adjective:</b> <a href='byond://?_src_=prefs;preference=adjective;task=input'>Change</a><br><i>[adjective]</i>"
+	dat += "<b>Adjective:</b> <a href='byond://?_src_=prefs;preference=custom_desc;task=input'>Change</a><br>"
 
-	dat += "<br><br>"
-	dat += "<b>Descriptor:</b> <a href='byond://?_src_=prefs;preference=descriptor;task=input'>Change</a><br><i>[descriptor]</i>"
+	dat += "<b>Descriptor:</b> <a href='byond://?_src_=prefs;preference=custom_noun;task=input'>Change</a><br>"
+
+	dat += "You look like [custom_desc] [custom_noun]."
 
 	dat += "<br><br>"
 	dat += "<b>Character Link:</b> <a href='byond://?_src_=prefs;preference=ooc_link;task=input'>Change</a><br><i>[ooc_link]</i>"

--- a/code/modules/vtr13/preferences/html_procs/character_settings_page.dm
+++ b/code/modules/vtr13/preferences/html_procs/character_settings_page.dm
@@ -14,7 +14,7 @@
 	dat += "<a href='byond://?_src_=prefs;preference=true_name;task=input'>[true_real_name]</a><BR>"
 
 	if(!(AGENDER in pref_species.species_traits))
-		dat += "<b>Gender:</b> <a href='byond://?_src_=prefs;preference=gender'>[gender == MALE ? "Male" : gender == FEMALE ? "Female" : "Other"]</a>"
+		dat += "<b>Gender:</b> <a href='byond://?_src_=prefs;preference=gender'>[gender == MALE ? "Male" : gender == FEMALE ? "Female" : gender == PLURAL ? "Other (They/Them)" : "Other (It/Its)"]</a>"
 	dat += "<BR><b>Body Type:</b> <a href='byond://?_src_=prefs;preference=body_type'>[body_type == MALE ? "Masculine" : body_type == FEMALE ? "Feminine" : "Other"]</a>"
 	if(pref_species.name == "Vampire" || pref_species.name == "Ghoul" || pref_species.name == "Werewolf")
 		dat += "<br><b>Biological Age:</b> <a href='byond://?_src_=prefs;preference=age;task=input'>[age]</a>"
@@ -187,6 +187,12 @@
 	dat += "<b>Headshot(1:1):</b> <a href='byond://?_src_=prefs;preference=headshot;task=input'>Change</a>"
 	if(headshot_link != null)
 		dat += " <a href='byond://?_src_=prefs;preference=view_headshot;task=input'>View</a>"
+	dat += "<br><br>"
+	dat += "<b>Adjective:</b> <a href='byond://?_src_=prefs;preference=adjective;task=input'>Change</a><br><i>[adjective]</i>"
+
+	dat += "<br><br>"
+	dat += "<b>Descriptor:</b> <a href='byond://?_src_=prefs;preference=descriptor;task=input'>Change</a><br><i>[descriptor]</i>"
+
 	dat += "<br><br>"
 	dat += "<b>Character Link:</b> <a href='byond://?_src_=prefs;preference=ooc_link;task=input'>Change</a><br><i>[ooc_link]</i>"
 

--- a/code/modules/vtr13/preferences/preferences_defines.dm
+++ b/code/modules/vtr13/preferences/preferences_defines.dm
@@ -169,7 +169,7 @@
 	var/flavor_text
 	var/ooc_notes
 	var/headshot_link
-	var/custom_desc = "a"				//Adjective shown on examine
+	var/custom_desc = "an off-putting"	//Adjective shown on examine
 	var/custom_noun = "person"			//Noun used to describe character on examine
 	var/hair_color = "000"				//Hair color
 	var/facial_hair_color = "000"		//Facial hair color

--- a/code/modules/vtr13/preferences/preferences_defines.dm
+++ b/code/modules/vtr13/preferences/preferences_defines.dm
@@ -169,8 +169,8 @@
 	var/flavor_text
 	var/ooc_notes
 	var/headshot_link
-	var/adjective
-	var/descriptor
+	var/custom_desc = "a"				//Adjective shown on examine
+	var/custom_noun = "person"			//Noun used to describe character on examine
 	var/hair_color = "000"				//Hair color
 	var/facial_hair_color = "000"		//Facial hair color
 	var/hairstyle = "Bald"				//Hair type

--- a/code/modules/vtr13/preferences/preferences_defines.dm
+++ b/code/modules/vtr13/preferences/preferences_defines.dm
@@ -169,6 +169,8 @@
 	var/flavor_text
 	var/ooc_notes
 	var/headshot_link
+	var/adjective
+	var/descriptor
 	var/hair_color = "000"				//Hair color
 	var/facial_hair_color = "000"		//Facial hair color
 	var/hairstyle = "Bald"				//Hair type

--- a/code/modules/vtr13/preferences/savfile_procs/_load_character.dm
+++ b/code/modules/vtr13/preferences/savfile_procs/_load_character.dm
@@ -57,6 +57,12 @@
 	READ_FILE(S["ooc_notes"], ooc_notes)
 	ooc_notes = sanitize_text(ooc_notes)
 
+	READ_FILE(S["custom_desc"], custom_desc)
+	custom_desc = sanitize_text(custom_desc)
+
+	READ_FILE(S["custom_noun"], custom_noun)
+	custom_noun = sanitize_text(custom_noun)
+
 	READ_FILE(S["headshot_link"], headshot_link)
 	if(!valid_headshot_link(null, headshot_link, TRUE))
 		headshot_link = null

--- a/code/modules/vtr13/preferences/savfile_procs/_load_character.dm
+++ b/code/modules/vtr13/preferences/savfile_procs/_load_character.dm
@@ -59,9 +59,13 @@
 
 	READ_FILE(S["custom_desc"], custom_desc)
 	custom_desc = sanitize_text(custom_desc)
+	if(!custom_desc)
+		custom_desc = "an off-putting"
 
 	READ_FILE(S["custom_noun"], custom_noun)
 	custom_noun = sanitize_text(custom_noun)
+	if(!custom_noun)
+		custom_noun = "person"
 
 	READ_FILE(S["headshot_link"], headshot_link)
 	if(!valid_headshot_link(null, headshot_link, TRUE))

--- a/code/modules/vtr13/preferences/savfile_procs/_reset_character.dm
+++ b/code/modules/vtr13/preferences/savfile_procs/_reset_character.dm
@@ -5,7 +5,7 @@
 	ooc_notes = null
 	flavor_text = null
 	headshot_link = null // TFN EDIT
-	custom_desc = "a"
+	custom_desc = "an off-putting"
 	custom_noun = "person"
 	info_known = INFO_KNOWN_UNKNOWN
 	QDEL_NULL(stats)

--- a/code/modules/vtr13/preferences/savfile_procs/_reset_character.dm
+++ b/code/modules/vtr13/preferences/savfile_procs/_reset_character.dm
@@ -5,6 +5,8 @@
 	ooc_notes = null
 	flavor_text = null
 	headshot_link = null // TFN EDIT
+	custom_desc = "a"
+	custom_noun = "person"
 	info_known = INFO_KNOWN_UNKNOWN
 	QDEL_NULL(stats)
 	stats = new()

--- a/code/modules/vtr13/preferences/savfile_procs/_save_character.dm
+++ b/code/modules/vtr13/preferences/savfile_procs/_save_character.dm
@@ -18,6 +18,8 @@
 	WRITE_FILE(S["age"], age)
 	WRITE_FILE(S["flavor_text"], flavor_text)
 	WRITE_FILE(S["ooc_notes"], ooc_notes)
+	WRITE_FILE(S["custom_desc"], custom_desc)
+	WRITE_FILE(S["custom_noun"], custom_noun)
 	WRITE_FILE(S["headshot_link"], headshot_link) // TFN EDIT: headshot saving
 	WRITE_FILE(S["hair_color"], hair_color)
 	WRITE_FILE(S["facial_hair_color"], facial_hair_color)

--- a/code/modules/vtr13/preferences/topic_procs/process_input_task_links.dm
+++ b/code/modules/vtr13/preferences/topic_procs/process_input_task_links.dm
@@ -268,8 +268,8 @@
 		if("decrease_stat")
 			var/datum/attribute/A = locate(href_list["attribute"])
 			A.score--
-			if(A.name == "Charisma" && custom_desc != "a") //Only reset our current descriptor if we're lowering Charisma and we didn't already reset to "a"
-				custom_desc = "a"
+			if(A.name == "Charisma" && custom_desc != "an off-putting") //Only reset our current descriptor if we're lowering Charisma and we didn't already reset to "a"
+				custom_desc = "an off-putting"
 				to_chat(user, "<font color='red'>Your chosen descriptor has been reset.</font>")
 
 		if("increase_potency")

--- a/code/modules/vtr13/preferences/topic_procs/process_input_task_links.dm
+++ b/code/modules/vtr13/preferences/topic_procs/process_input_task_links.dm
@@ -471,13 +471,13 @@
 		if("custom_desc")
 			var/list/desc_options = compile_adjectives()
 			var/new_desc = tgui_input_list(user, "Select an adjective:", "Adjective", desc_options)
-			if(new_desc != custom_desc)
+			if(new_desc)
 				custom_desc = new_desc
 
 		if("custom_noun")
 			var/list/noun_options = compile_nouns()
 			var/new_noun = tgui_input_list(user, "Select your primary descriptor:", "Descriptor", noun_options)
-			if(new_noun != custom_noun)
+			if(new_noun)
 				custom_noun = new_noun
 
 		if("headshot")

--- a/code/modules/vtr13/preferences/topic_procs/process_input_task_links.dm
+++ b/code/modules/vtr13/preferences/topic_procs/process_input_task_links.dm
@@ -268,6 +268,9 @@
 		if("decrease_stat")
 			var/datum/attribute/A = locate(href_list["attribute"])
 			A.score--
+			if(A.name == "Charisma" && custom_desc != "a") //Only reset our current descriptor if we're lowering Charisma and we didn't already reset to "a"
+				custom_desc = "a"
+				to_chat(user, "<font color='red'>Your chosen descriptor has been reset.</font>")
 
 		if("increase_potency")
 			set_potency(get_potency() + 1)
@@ -465,15 +468,17 @@
 			popup.open(FALSE)
 			return
 
-		if("adjective")
-			var/new_adj_1 = tgui_alert(user, "Select an adjective:", "Adjective", list("foo", "bar", "meow"))
-			if(new_adj_1 != adjective)
-				adjective = new_adj_1
+		if("custom_desc")
+			var/list/desc_options = compile_adjectives()
+			var/new_desc = tgui_input_list(user, "Select an adjective:", "Adjective", desc_options)
+			if(new_desc != custom_desc)
+				custom_desc = new_desc
 
-		if("descriptor")
-			var/new_adj_2 = tgui_alert(user, "Select your primary descriptor:", "Descriptor", list("oof", "rab", "woem"))
-			if(new_adj_2 != descriptor)
-				descriptor = new_adj_2
+		if("custom_noun")
+			var/list/noun_options = compile_nouns()
+			var/new_noun = tgui_input_list(user, "Select your primary descriptor:", "Descriptor", noun_options)
+			if(new_noun != custom_noun)
+				custom_noun = new_noun
 
 		if("headshot")
 			to_chat(user, span_notice("Please use a relatively SFW image of the head and shoulder area to maintain immersion level. Lastly, ["<b>do not use a real life photo or use any image that is less than serious.</b>"]"))

--- a/code/modules/vtr13/preferences/topic_procs/process_input_task_links.dm
+++ b/code/modules/vtr13/preferences/topic_procs/process_input_task_links.dm
@@ -465,6 +465,16 @@
 			popup.open(FALSE)
 			return
 
+		if("adjective")
+			var/new_adj_1 = tgui_alert(user, "Select an adjective:", "Adjective", list("foo", "bar", "meow"))
+			if(new_adj_1 != adjective)
+				adjective = new_adj_1
+
+		if("descriptor")
+			var/new_adj_2 = tgui_alert(user, "Select your primary descriptor:", "Descriptor", list("oof", "rab", "woem"))
+			if(new_adj_2 != descriptor)
+				descriptor = new_adj_2
+
 		if("headshot")
 			to_chat(user, span_notice("Please use a relatively SFW image of the head and shoulder area to maintain immersion level. Lastly, ["<b>do not use a real life photo or use any image that is less than serious.</b>"]"))
 			to_chat(user, span_notice("If the photo doesn't show up properly in-game, ensure that it's a direct image link that opens properly in a browser."))

--- a/code/modules/wod13/npc.dm
+++ b/code/modules/wod13/npc.dm
@@ -3,6 +3,8 @@
 
 /mob/living/carbon/human/npc
 	name = "Loh ebanii"
+	custom_desc = "an ordinary"
+	custom_noun = "person"
 	/// Until we do a full NPC refactor (see: rewriting every single bit of code)
 	/// use this to determine NPC weapons and their chances to spawn with them -- assuming you want the NPC to do that
 	/// Otherwise just set it under the NPC's type as
@@ -183,6 +185,8 @@
 	var/list/surnames = list("Durden",
 		"Polson",
 		"Singer")
+	var/list/stock_descs = list("a normal", "an ordinary", "a plain", "a regular", "a simple", "a typical", "an everyday", "an average", "an unremarkable")
+	var/list/stock_nouns = list("person","gentleperson","individual","figure")
 
 	//Hair shit
 	var/list/hair_colors = list("040404",	//Black
@@ -418,6 +422,8 @@
 			s_names = socialrole.surnames
 		else
 			s_names = GLOB.last_names
+		custom_desc = pick(socialrole.stock_descs)
+		custom_noun = pick(socialrole.stock_nouns)
 		age = rand(socialrole.min_age, socialrole.max_age)
 		if(socialrole.s_tones_force)
 			skin_tone = socialrole.s_tones_force

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3870,6 +3870,7 @@
 #include "code\modules\vtr13\objects\elements\silvered.dm"
 #include "code\modules\vtr13\panicbunker\panicbunker.dm"
 #include "code\modules\vtr13\preferences\copy_to.dm"
+#include "code\modules\vtr13\preferences\descriptions\compile_desc_terms.dm"
 #include "code\modules\vtr13\preferences\preferences_defines.dm"
 #include "code\modules\vtr13\preferences\preferences_setup.dm"
 #include "code\modules\vtr13\preferences\global_procs\make_font_cool.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows players to select a specific adjective + noun combo used to describe their character on examine, replacing the current usage of words that directly relate to their charisma and physique. Each point of charisma, up to 6, opens up more options for adjectives; all nouns are available regardless of stats. 

Implementation is not perfect; ideally I would have liked to do this in a datumized and easily expanded way, but after procrastinating this for several months, I sat down this morning and said "I have got to just get this done". Obviously I'm wary about **anything** that involves touching saves, but that's been tested and as far as I can see (in a worst-case scenario) none of this should touch any _existing_ save data.

## Why It's Good For The Game

Roadmapped feature.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="265" height="255" alt="image" src="https://github.com/user-attachments/assets/f12233d3-0103-453a-811a-7ca87ae1994a" />
<img width="225" height="225" alt="image" src="https://github.com/user-attachments/assets/f0fc1044-8d5b-4817-bd78-a8c43f2d23e0" />


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added selectable "descriptors" that are shown when examined, i.e. "This is Dave Space, a dapper guy". The higher your charisma stat, the more adjectives you can choose from.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
