### PR TITLE
Sunglasses/tinted glasses hide eyes but don't flash protect

### DIFF
--- a/code/modules/vtr13/items/clothing/glasses.dm
+++ b/code/modules/vtr13/items/clothing/glasses.dm
@@ -8,11 +8,13 @@
 	name = "white veil"
 	desc = "A white lace veil that covers the eyes."
 	icon_state = "white_veil"
+	flags_inv = HIDEEYES
 
 /obj/item/clothing/glasses/vampire/vtr/black_veil
 	name = "black veil"
 	desc = "A dark veil that obscures the wearer's face."
 	icon_state = "black_veil"
+	flags_inv = HIDEEYES
 
 /obj/item/clothing/glasses/vampire/vtr/metalframe
 	name = "prescription aviators"
@@ -36,6 +38,7 @@
 	name = "bicolor sunglasses"
 	desc = "These let you see the whole world in 3D."
 	icon_state = "3d"
+	flags_inv = HIDEEYES
 
 /obj/item/clothing/glasses/vampire/vtr/safetygoggles
 	name = "safety goggles"
@@ -46,11 +49,13 @@
 	name = "oversized sunglasses"
 	desc = "Oversized visor sunglasses, extra cool at night."
 	icon_state = "bigsunglasses"
+	flags_inv = HIDEEYES
 
 /obj/item/clothing/glasses/vampire/vtr/thinsunglasses
 	name = "thin sunglasses"
 	desc = "Stay in Wonderland and I'll show you how deep the rabbit hole goes."
 	icon_state = "sun_thin"
+	flags_inv = HIDEEYES
 
 /obj/item/clothing/glasses/vampire/vtr/eyepatch
 	name = "right eyepatch"
@@ -76,18 +81,22 @@
 	name = "aviators"
 	desc = "What's our vector, Victor?"
 	icon_state = "aviator"
+	flags_inv = HIDEEYES
 
 /obj/item/clothing/glasses/vampire/vtr/aviator_green
 	name = "green aviators"
 	desc = "They're better for the environment."
 	icon_state = "aviator_green"
+	flags_inv = HIDEEYES
 
 /obj/item/clothing/glasses/vampire/vtr/aviator_blue
 	name = "blue aviators"
 	desc = "Gives you a more pessimistic view of the past."
 	icon_state = "aviator_blue"
+	flags_inv = HIDEEYES
 
 /obj/item/clothing/glasses/vampire/vtr/aviator_red
 	name = "red aviators"
 	desc = "Absolutely do not make you look like a vampire."
 	icon_state = "aviator_red"
+	flags_inv = HIDEEYES

--- a/code/modules/wod13/items/clothes/eyes.dm
+++ b/code/modules/wod13/items/clothes/eyes.dm
@@ -14,12 +14,14 @@
 	desc = "Fuck it, Dude, let's go bowling."
 	icon_state = "yellow"
 	inhand_icon_state = "glasses"
+	flags_inv = HIDEEYES
 
 /obj/item/clothing/glasses/vampire/red
 	name = "red aviators"
 	desc = "Absolutely do not make you look like a vampire."
 	icon_state = "redg"
 	inhand_icon_state = "glasses"
+	flags_inv = HIDEEYES
 
 /obj/item/clothing/glasses/vampire/sun
 	name = "sunglasses"
@@ -27,7 +29,7 @@
 	icon_state = "sun"
 	inhand_icon_state = "glasses"
 	darkness_view = 1
-	flash_protect = FLASH_PROTECTION_FLASH
+	flags_inv = HIDEEYES
 
 /obj/item/clothing/glasses/vampire/perception
 	name = "perception glasses"


### PR DESCRIPTION

## About The Pull Request

Adds the eye hide flag to sunglasses and otherwise tinted glasses. Removes flash protection from the basic 'sunglasses' item for balance reasons in the 1% chance flashbangs ever show up.

## Why It's Good For The Game

Gangrel should be able to do weird shit with their eyes if they're wearing cool shades. For dramatic effect.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

:cl:
balance: sunglasses hide eys.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
